### PR TITLE
[FEAT] 페이지네이션 컴포넌트 리펙토링

### DIFF
--- a/src/app/test/pagination/page.tsx
+++ b/src/app/test/pagination/page.tsx
@@ -1,4 +1,4 @@
-import { Pagination } from '@/shared/ui/';
+// import { Pagination } from '@/shared/ui/';
 import React from 'react';
 
 const Page = () => {
@@ -8,7 +8,7 @@ const Page = () => {
         {/* Page Button */}
         <div className="py-[8px] text-1xl font-medium">PAGE BUTTON</div>
         <div className="flex flex-row items-center">
-          <Pagination currentPage={1} maxPage={20} count={7} />
+          {/* <Pagination currentPage={1} maxPage={20} count={7} /> */}
         </div>
       </div>
     </div>

--- a/src/shared/ui/buttons/PaginationButton.tsx
+++ b/src/shared/ui/buttons/PaginationButton.tsx
@@ -2,32 +2,17 @@
 
 import { cn } from '@/shared/lib/';
 import { cva, VariantProps } from 'class-variance-authority';
-import React, { createContext, useContext } from 'react';
+import React, { forwardRef } from 'react';
 import PageLeftDoubleChevron from '../icons/pagination/PageLeftDoubleChevron';
 import PageLeftChevron from '../icons/pagination/PageLeftChevron';
 import PageRightChevron from '../icons/pagination/PageRightChevron';
 import PageRightDoubleChevron from '../icons/pagination/PageRightDoubleChevron';
 
-interface PaginationContextType {
-  current: number;
-  setCurrent: (page: number) => void;
-  maxPage: number;
-  count: number;
-}
-
-export const PaginationContext = createContext<PaginationContextType | null>(null);
-
-export const usePagination = () => {
-  const context = useContext(PaginationContext);
-  if (!context) {
-    throw new Error('You must use this hook only within the Pagination component.');
-  }
-  return context;
-};
-
 interface PaginationProps {
   /**@param {number} currentPage 현재 화면에 보여줄 페이지 */
   currentPage: number;
+  /**@param {function} setPage 상위 컴포넌트에서 페이지를 설정하는 함수 */
+  setPage: (page: number) => void;
   /**@param {number} maxPage 전체 페이지 개수 */
   maxPage: number;
   /**
@@ -40,72 +25,65 @@ interface PaginationProps {
 /**
  * @see https://www.figma.com/design/2ks26SvLcpmEHmzSETR8ky/Trend-Now_Design-File?node-id=6-2378&t=cbvmKV4XEswTU85f-4
  */
-const Pagination = React.forwardRef<HTMLDivElement, PaginationProps>(
-  ({ currentPage, maxPage, count, ...props }, ref) => {
-    const [current, setCurrent] = React.useState<number>(currentPage);
+const Pagination = forwardRef<HTMLDivElement, PaginationProps>(
+  ({ currentPage, setPage, maxPage, count, ...props }, ref) => {
+    // 현재 페이지가 속한 페이지 그룹 (예: 6페이지면 2번째 그룹)
+    const currentPageGroup = Math.ceil(currentPage / count);
 
-    const currentPageGroup = Math.ceil(current / count);
+    // 현재 그룹의 시작 페이지 번호 계산
     const startPage = (currentPageGroup - 1) * count + 1;
+
+    // 실제로 렌더링할 페이지 수 (마지막 그룹일 경우 count보다 작을 수 있음)
     const visiblePageCount = Math.min(maxPage - startPage + 1, count);
 
+    // << 버튼 클릭 시, 이전 페이지 그룹으로 이동
+    const handleFirstGroup = () => {
+      const prevPageGroup = Math.floor((currentPage - 1) / count);
+      setPage(prevPageGroup > 0 ? prevPageGroup * count : 1);
+    };
+
+    // < 버튼 클릭 시, 이전 페이지로 이동
+    const handlePrev = () => {
+      if (currentPage > 1) setPage(currentPage - 1);
+    };
+
+    // > 버튼 클릭 시, 다음 페이지로 이동
+    const handleNext = () => {
+      if (currentPage < maxPage) setPage(currentPage + 1);
+    };
+
+    // >> 버튼 클릭 시, 다음 페이지 그룹으로 이동
+    const handleLastGroup = () => {
+      const lastGroup = Math.ceil(maxPage / count);
+      if (currentPageGroup < lastGroup) {
+        setPage(currentPageGroup * count + 1);
+      } else {
+        setPage(maxPage);
+      }
+    };
+
     return (
-      <PaginationContext.Provider value={{ current, setCurrent, maxPage, count }}>
-        <div ref={ref} className="flex flex-row justify-center gap-x-2" {...props}>
-          <span
-            className="cursor-pointer"
-            onClick={() => {
-              const prevPageGroup = Math.floor((current - 1) / count);
-
-              if (prevPageGroup > 0) {
-                setCurrent(prevPageGroup * count);
-              } else {
-                setCurrent(1);
-              }
-            }}
-          >
-            <PageLeftDoubleChevron />
-          </span>
-          <span
-            className="cursor-pointer"
-            onClick={() => {
-              if (current - 1 > 0) setCurrent((prev) => prev - 1);
-            }}
-          >
-            <PageLeftChevron />
-          </span>
-          {new Array(visiblePageCount).fill(0).map((_, idx) => {
-            idx += 1;
-
-            if (idx % count === current % count) {
-              return <PageButton key={idx} page={startPage + idx - 1} variant="current" />;
-            } else {
-              return <PageButton key={idx} page={startPage + idx - 1} variant="default" />;
-            }
-          })}
-          <span
-            className="cursor-pointer"
-            onClick={() => {
-              if (current + 1 <= maxPage) setCurrent((prev) => prev + 1);
-            }}
-          >
-            <PageRightChevron />
-          </span>
-          <span
-            className="cursor-pointer"
-            onClick={() => {
-              if (Math.ceil(maxPage / count) > currentPageGroup) {
-                setCurrent(currentPageGroup * count + 1);
-              } else if (current === maxPage) {
-                return;
-              } else {
-                setCurrent(maxPage);
-              }
-            }}
-          >
-            <PageRightDoubleChevron />
-          </span>
-        </div>
-      </PaginationContext.Provider>
+      <div ref={ref} className="flex flex-row justify-center gap-x-2" {...props}>
+        <span className="cursor-pointer" onClick={handleFirstGroup}>
+          <PageLeftDoubleChevron />
+        </span>
+        <span className="cursor-pointer" onClick={handlePrev}>
+          <PageLeftChevron />
+        </span>
+        {Array.from({ length: visiblePageCount }, (_, idx) => {
+          const page = startPage + idx;
+          const variant = page === currentPage ? 'current' : 'default';
+          return (
+            <PageButton key={page} page={page} variant={variant} onClick={() => setPage(page)} />
+          );
+        })}
+        <span className="cursor-pointer" onClick={handleNext}>
+          <PageRightChevron />
+        </span>
+        <span className="cursor-pointer" onClick={handleLastGroup}>
+          <PageRightDoubleChevron />
+        </span>
+      </div>
     );
   }
 );
@@ -137,22 +115,12 @@ interface ButtonProps
 /**
  * @see https://www.figma.com/design/2ks26SvLcpmEHmzSETR8ky/Trend-Now_Design-File?node-id=6-2378&t=cbvmKV4XEswTU85f-4
  */
-const PageButton = React.forwardRef<HTMLButtonElement, ButtonProps>(
-  ({ page, variant, className, ...props }, ref) => {
-    const { setCurrent } = usePagination();
-    return (
-      <button
-        ref={ref}
-        className={cn(pageButtonVariants({ variant }), className)}
-        onClick={() => setCurrent(page)}
-        {...props}
-      >
-        {page}
-      </button>
-    );
-  }
-);
-
-PageButton.displayName = 'PageButton';
+const PageButton = ({ page, variant, className, ...props }: ButtonProps) => {
+  return (
+    <button className={cn(pageButtonVariants({ variant }), className)} {...props}>
+      {page}
+    </button>
+  );
+};
 
 export default Pagination;

--- a/src/views/boards/ui/Board.tsx
+++ b/src/views/boards/ui/Board.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { DateDivider, Pagination, Pencil24, PrimaryButton } from '@/shared/ui';
+import { DateDivider, Pencil24, PrimaryButton } from '@/shared/ui';
 import React from 'react';
 import { BoardList } from '@/widgets/boards';
 import { usePathname, useRouter } from 'next/navigation';
@@ -41,7 +41,7 @@ export default function Board({ type }: BoardProps) {
           </div>
         </div>
         <BoardList />
-        <Pagination currentPage={1} maxPage={20} count={5} />
+        {/* <Pagination currentPage={1} maxPage={20} count={5} /> */}
       </div>
     </div>
   );

--- a/src/views/hotBoards/ui/HotBoard.tsx
+++ b/src/views/hotBoards/ui/HotBoard.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { DateDivider, Pagination, Pencil24, PrimaryButton, SecondaryButton } from '@/shared/ui';
+import { DateDivider, Pencil24, PrimaryButton, SecondaryButton } from '@/shared/ui';
 import React from 'react';
 import Image from 'next/image';
 import { BoardList } from '@/widgets/boards';
@@ -71,7 +71,7 @@ export default function HotBoard({ keyword }: HotBoardProps) {
           </PrimaryButton>
         </div>
         <BoardList />
-        <Pagination currentPage={1} maxPage={20} count={5} />
+        {/* <Pagination currentPage={1} maxPage={20} count={5} /> */}
       </div>
     </div>
   );

--- a/src/views/mypage/comments/ui/MyComments.tsx
+++ b/src/views/mypage/comments/ui/MyComments.tsx
@@ -1,4 +1,4 @@
-import { Pagination } from '@/shared/ui';
+// import { Pagination } from '@/shared/ui';
 import { MyCommentRow } from '@/widgets/mypage';
 import React from 'react';
 
@@ -21,7 +21,7 @@ const MyComments = () => {
         ))}
       </div>
       {/* 페이지네이션 */}
-      <Pagination currentPage={1} maxPage={20} count={5} />
+      {/* <Pagination currentPage={1} maxPage={20} count={5} /> */}
     </div>
   );
 };

--- a/src/views/mypage/posts/ui/MyPosts.tsx
+++ b/src/views/mypage/posts/ui/MyPosts.tsx
@@ -1,4 +1,4 @@
-import { Pagination } from '@/shared/ui';
+// import { Pagination } from '@/shared/ui';
 import { MyPostRow } from '@/widgets/mypage';
 import React from 'react';
 
@@ -31,7 +31,7 @@ const MyPosts = () => {
         ))}
       </div>
       {/* 페이지네이션 */}
-      <Pagination currentPage={1} maxPage={20} count={5} />
+      {/* <Pagination currentPage={1} maxPage={20} count={5} /> */}
     </div>
   );
 };

--- a/src/views/mypage/scraps/ui/MyScraps.tsx
+++ b/src/views/mypage/scraps/ui/MyScraps.tsx
@@ -1,4 +1,4 @@
-import { Pagination } from '@/shared/ui';
+// import { Pagination } from '@/shared/ui';
 import { MyScrapRow } from '@/widgets/mypage';
 import React from 'react';
 
@@ -30,7 +30,7 @@ const MyScraps = () => {
         ))}
       </div>
       {/* 페이지네이션 */}
-      <Pagination currentPage={1} maxPage={20} count={5} />
+      {/* <Pagination currentPage={1} maxPage={20} count={5} /> */}
     </div>
   );
 };


### PR DESCRIPTION
## 변경 사항
페이지네이션 컴포넌트 리펙토링 및 일시적으로 주석 처리

## 세부 설명
- Pagination 컴포넌트를 내부 상태 관리에서 외부 상태(props: currentPage, setPage) 기반 컴포넌트로 리팩토링
- 불필요했던 Context API 및 usePagination 훅 제거
- 페이지 그룹 계산 및 핸들러(handlePrev 등) 함수들을 위로 분리
- 기존 페이지에서 페이지네이션 컴포넌트 주석 처리

## 관련 이슈


## 스크린샷 (선택 사항)


## 테스트 방법

## 체크리스트
- [x] 코드가 프로젝트의 코딩 스타일을 준수합니다
- [x] 자체 코드 리뷰를 수행했습니다
- [ ] 변경 사항에 대한 테스트가 추가/수정되었습니다
- [ ] 모든 테스트가 통과합니다
- [ ] 필요한 문서를 업데이트했습니다
