### PR TITLE
[FEAT] Quill 에디터에 customImage Blot 추가 및 HTML 변환 처리

### DIFF
--- a/src/features/write/lib/customImageBlot.ts
+++ b/src/features/write/lib/customImageBlot.ts
@@ -1,0 +1,29 @@
+import Quill from 'quill';
+import { BlockEmbed } from 'quill/blots/block';
+
+// 커스텀 이미지 블롯 정의
+class CustomImageBlot extends BlockEmbed {
+  static blotName = 'customImage'; // 델타에서 사용할 블롯 이름
+  static tagName = 'img'; // 실제 DOM에 삽입될 태그 (img 태그 사용)
+
+  // 에디터에 이미지 삽입할 때 호출되는 메서드
+  static create(value: { id: string; url: string }) {
+    const node = super.create() as HTMLElement; // 기본 img 요소 생성
+    node.setAttribute('src', value.url); // 이미지 URL 설정
+    node.setAttribute('data-id', value.id); // 추가 식별자(data-id) 설정
+    return node; // 최종 img 노드 반환
+  }
+
+  // 에디터로부터 델타(Delta)를 생성할 때 사용되는 메서드
+  static value(node: HTMLElement) {
+    return {
+      id: node.getAttribute('data-id'), // data-id 값을 델타에 포함
+      url: node.getAttribute('src'), // src 값을 델타에 포함
+    };
+  }
+}
+
+// 이미 같은 이름의 포맷이 등록되어 있는지 확인하고, 없다면 등록
+if (!Quill.imports['formats/customImage']) {
+  Quill.register(CustomImageBlot); // 커스텀 이미지 블롯을 Quill에 등록
+}

--- a/src/features/write/ui/PostWrite.tsx
+++ b/src/features/write/ui/PostWrite.tsx
@@ -5,6 +5,7 @@ import { useUserStore } from '@/shared/store';
 import { RichTextEditorHandle } from '@/shared/types';
 import { useRouter } from 'next/navigation';
 import { useRef } from 'react';
+import type { Delta } from 'quill';
 
 interface PostWriteProps {
   /** 게시판 이름 */
@@ -20,14 +21,27 @@ const PostWrite = ({ boardName, boardId, path }: PostWriteProps) => {
   const { jwt } = useUserStore();
   const editorRef = useRef<RichTextEditorHandle>(null); // 에디터 내용(DOM)이나 메서드에 접근하기 위한 ref
   const titleRef = useRef<HTMLInputElement>(null); // 제목 저장하는 ref
-  const imageIdsRef = useRef<number[]>([]); // 이미지 index 저장하는 ref
+
+  // Delta에서 img id 추출함수
+  const extractImageIdsFromDelta = (delta: Delta): number[] => {
+    const ids: number[] = [];
+    delta.ops.forEach((op) => {
+      if (typeof op.insert === 'object' && op.insert !== null) {
+        const insert = op.insert as { customImage?: { id: string | number } };
+        if (insert.customImage?.id) {
+          ids.push(Number(insert.customImage.id));
+        }
+      }
+    });
+
+    return ids;
+  };
 
   const handleSubmit = async () => {
     const title = titleRef.current?.value;
     const delta = editorRef.current?.getContents();
     const content = JSON.stringify(delta);
-    const imageIds = imageIdsRef.current;
-
+    const imageIds = extractImageIdsFromDelta(delta!);
     if (!title || !content) return alert('제목 또는 내용을 입력해주세요');
 
     if (!jwt) {
@@ -42,7 +56,6 @@ const PostWrite = ({ boardName, boardId, path }: PostWriteProps) => {
       boardName={boardName}
       titleRef={titleRef}
       editorRef={editorRef}
-      imageIdsRef={imageIdsRef}
       onSubmit={handleSubmit}
     />
   );

--- a/src/features/write/ui/RichTextEditor.tsx
+++ b/src/features/write/ui/RichTextEditor.tsx
@@ -6,107 +6,104 @@ import 'quill/dist/quill.snow.css'; // Import Quill styles
 import { axiosUploadImages } from '@/shared/api';
 import { ImageUploadResponse, RichTextEditorHandle } from '@/shared/types';
 import { useUserStore } from '@/shared/store';
+import '../lib/customImageBlot';
 
-interface RichTextEditorProps {
-  imageIdsRef: React.MutableRefObject<number[]>;
-}
+const RichTextEditor = forwardRef<RichTextEditorHandle>((_, ref) => {
+  const { jwt } = useUserStore();
+  const editorRef = useRef<HTMLDivElement>(null); // 에디터 컨테이너
+  const quillRef = useRef<Quill | null>(null); // Quill 인스턴스
 
-const RichTextEditor = forwardRef<RichTextEditorHandle, RichTextEditorProps>(
-  ({ imageIdsRef }, ref) => {
-    const { jwt } = useUserStore();
-    const editorRef = useRef<HTMLDivElement>(null); // 에디터 컨테이너
-    const quillRef = useRef<Quill | null>(null); // Quill 인스턴스
+  const imageHandler = useCallback(
+    (editor: Quill) => {
+      // 파일 입력창 생성
+      const input = document.createElement('input');
+      input.setAttribute('type', 'file');
+      input.setAttribute('accept', 'image/*');
+      input.setAttribute('name', 'file');
+      input.setAttribute('multiple', '');
+      input.click();
 
-    const imageHandler = useCallback(
-      (editor: Quill) => {
-        // 파일 입력창 생성
-        const input = document.createElement('input');
-        input.setAttribute('type', 'file');
-        input.setAttribute('accept', 'image/*');
-        input.setAttribute('name', 'file');
-        input.setAttribute('multiple', '');
-        input.click();
+      // 파일 선택 후 이벤트 처리
+      input.onchange = async (event: Event) => {
+        const target = event.target as HTMLInputElement;
+        const files = target.files;
+        if (!files || files.length === 0) return;
 
-        // 파일 선택 후 이벤트 처리
-        input.onchange = async (event: Event) => {
-          const target = event.target as HTMLInputElement;
-          const files = target.files;
-          if (!files || files.length === 0) return;
+        const formData = new FormData();
+        for (let i = 0; i < files.length; i++) {
+          formData.append('images', files[i]);
+        }
 
-          const formData = new FormData();
-          for (let i = 0; i < files.length; i++) {
-            formData.append('images', files[i]);
-          }
+        if (!jwt) {
+          // 로그인 안 된 상태이므로 요청 중단
+          return;
+        }
 
-          if (!jwt) {
-            // 로그인 안 된 상태이므로 요청 중단
-            return;
-          }
+        //  S3 업로드 요청
+        const response = await axiosUploadImages<ImageUploadResponse>(jwt, formData); // 다중 파일
 
-          //  S3 업로드 요청
-          const response = await axiosUploadImages<ImageUploadResponse>(jwt, formData); // 다중 파일
-
-          imageIdsRef.current.push(response.imageUploadDto[0].id); // imageIdsRef 업데이트
-          // Quill 에디터에 <img> 태그 추가
-          response?.imageUploadDto.forEach((img) => {
-            const range = editor.getSelection()!;
-            editor.insertEmbed(range.index, 'image', img.imageUrl);
-            editor.setSelection(range.index + 1);
+        // Quill 에디터에 <img> 태그 추가
+        response?.imageUploadDto.forEach((img) => {
+          const range = editor.getSelection()!;
+          editor.insertEmbed(range.index, 'customImage', {
+            url: img.imageUrl,
+            id: img.id,
           });
-        };
-      },
-      [jwt]
-    );
+          editor.setSelection(range.index + 1);
+        });
+      };
+    },
+    [jwt]
+  );
 
-    useEffect(() => {
-      // 에디터 DOM이 아직 렌더링되지 않은 경우 실행하지 않음
-      if (!editorRef.current) return;
+  useEffect(() => {
+    // 에디터 DOM이 아직 렌더링되지 않은 경우 실행하지 않음
+    if (!editorRef.current) return;
 
-      // Quill이 이미 초기화된 경우 중복 초기화를 방지
-      if (quillRef.current) return;
+    // Quill이 이미 초기화된 경우 중복 초기화를 방지
+    if (quillRef.current) return;
 
-      const quill = new Quill(editorRef.current, {
-        theme: 'snow',
-        placeholder: '내용을 입력하세요.',
-        modules: {
-          toolbar: {
-            container: [
-              [{ header: [1, 2, 3, false] }],
-              ['bold', 'italic', 'underline', 'strike'],
-              [{ list: 'ordered' }, { list: 'bullet' }],
-              ['link', 'image'],
-            ],
-            handlers: {
-              image: () => {
-                imageHandler(quill);
-              },
+    const quill = new Quill(editorRef.current, {
+      theme: 'snow',
+      placeholder: '내용을 입력하세요.',
+      modules: {
+        toolbar: {
+          container: [
+            [{ header: [1, 2, 3, false] }],
+            ['bold', 'italic', 'underline', 'strike'],
+            [{ list: 'ordered' }, { list: 'bullet' }],
+            ['link', 'image'],
+          ],
+          handlers: {
+            image: () => {
+              imageHandler(quill);
             },
           },
         },
-      });
-
-      quillRef.current = quill;
-
-      // quill.on('text-change', () => {
-      //   console.log('Text change!');
-      // });
-
-      // return () => {
-      //   quillRef.current = null; // Cleanup to avoid memory leaks
-      // };
-    }, []);
-
-    // 부모 컴포넌트가 getContents 함수를 사용할 수 있도록 연결한다
-    useImperativeHandle(ref, () => ({
-      getContents: () => quillRef.current?.getContents() ?? new Delta(),
-      setContents: (delta: Delta) => {
-        quillRef.current?.setContents(delta, 'api');
       },
-    }));
+    });
 
-    return <div ref={editorRef} style={{ height: '300px' }} />;
-  }
-);
+    quillRef.current = quill;
+
+    // quill.on('text-change', () => {
+    //   console.log('Text change!');
+    // });
+
+    // return () => {
+    //   quillRef.current = null; // Cleanup to avoid memory leaks
+    // };
+  }, [imageHandler]);
+
+  // 부모 컴포넌트가 getContents 함수를 사용할 수 있도록 연결한다
+  useImperativeHandle(ref, () => ({
+    getContents: () => quillRef.current?.getContents() ?? new Delta(),
+    setContents: (delta: Delta) => {
+      quillRef.current?.setContents(delta, 'api');
+    },
+  }));
+
+  return <div ref={editorRef} style={{ height: '300px' }} />;
+});
 
 RichTextEditor.displayName = 'RichTextEditor';
 

--- a/src/features/write/ui/Write.tsx
+++ b/src/features/write/ui/Write.tsx
@@ -5,7 +5,7 @@ import { RichTextEditorHandle } from '@/shared/types';
 import { InputFieldTitle, PrimaryButton } from '@/shared/ui';
 import dynamic from 'next/dynamic';
 import Image from 'next/image';
-import type { RefObject, MutableRefObject } from 'react';
+import type { RefObject } from 'react';
 
 // Quill이 SSR 중 로딩되지 않도록 방지
 const RichTextEditor = dynamic(() => import('@/features/write/ui/RichTextEditor'), {
@@ -21,10 +21,6 @@ interface WriteProps {
   titleRef: RefObject<HTMLInputElement | null>;
   /** 에디터 인스턴스(ref)를 통한 getContents, setContents 접근 (추후 옵셔널 삭제)*/
   editorRef: RefObject<RichTextEditorHandle | null>;
-  /** 업로드된 이미지 ID 목록을 저장하는 ref (추후 옵셔널 삭제)*/
-  imageIdsRef: MutableRefObject<number[]>;
-  /** 삭제할 이미지 ID 목록 (수정 시에만 사용됨) */
-  deleteImageIdsRef?: MutableRefObject<number[]>;
   /** 게시글 등록 또는 수정 버튼 클릭 시 호출되는 함수 (추후 옵셔널 삭제)*/
   onSubmit: () => void;
 }
@@ -34,9 +30,6 @@ export default function Write({
   isHotBoard = false,
   titleRef,
   editorRef,
-  imageIdsRef,
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  deleteImageIdsRef,
   onSubmit,
 }: WriteProps) {
   return (
@@ -76,7 +69,7 @@ export default function Write({
             <div className="flex flex-col gap-y-1">
               <span className="text-xs font-regular text-gray-800">내용</span>
               <div>
-                <RichTextEditor ref={editorRef} imageIdsRef={imageIdsRef} />
+                <RichTextEditor ref={editorRef} />
               </div>
             </div>
           </div>

--- a/src/widgets/post/ui/Content.tsx
+++ b/src/widgets/post/ui/Content.tsx
@@ -9,8 +9,19 @@ export default function Content({ post }: { post: PostDetail }) {
   let html = '';
   try {
     const delta = JSON.parse(post.content);
-    const converter = new QuillDeltaToHtmlConverter(delta.ops, {});
+    const converter = new QuillDeltaToHtmlConverter(delta.ops);
+
+    converter.renderCustomWith((customOp) => {
+      if (customOp.insert.type === 'customImage') {
+        const { id, url } = customOp.insert.value;
+
+        return `<img src="${url}" data-id="${id}" />`;
+      }
+
+      return '';
+    });
     html = converter.convert();
+    console.log(html);
   } catch {
     html = post.content;
   }


### PR DESCRIPTION
## 변경 사항
- imageIdsRef, deleteImageIdsRef 제거
- Quill 에디터에 customImage 블롯 추가 (<img src="..." data-id="...">)
- 게시글 제출 시 Delta에서 image ID 추출 로직 추가
- Delta → HTML 변환 시 customImage 블롯을 위한 커스텀 추가

## 세부 설명
커스텀 이미지 삽입 시 data-id 속성을 포함하는 <img> 태그를 생성하는 블롯을 구현했습니다.
이미지가 삭제될 경우를 고려해 image ID는 Delta에서 직접 추출하도록 변경했습니다. (불필요한 ref 제거)

## 관련 이슈

## 스크린샷 (선택 사항)

## 테스트 방법

## 체크리스트
- [x] 코드가 프로젝트의 코딩 스타일을 준수합니다
- [x] 자체 코드 리뷰를 수행했습니다
- [ ] 변경 사항에 대한 테스트가 추가/수정되었습니다
- [ ] 모든 테스트가 통과합니다
- [ ] 필요한 문서를 업데이트했습니다
