### PR TITLE
[FEAT] 게시물 수정 기능 구현

### DIFF
--- a/src/app/(main)/(boards)/[board]/post/[postId]/edit/page.tsx
+++ b/src/app/(main)/(boards)/[board]/post/[postId]/edit/page.tsx
@@ -1,0 +1,15 @@
+import { PostEdit } from '@/features/write';
+import { BOARD_MAP } from '@/shared/constants';
+import { BoardType } from '@/shared/types';
+
+export default async function Page({
+  params,
+}: {
+  params: Promise<{ board: string; postId: string }>;
+}) {
+  const { board, postId } = await params;
+  const boardName = BOARD_MAP[board as BoardType].name;
+  const boardId = BOARD_MAP[board as BoardType].id;
+  const path = BOARD_MAP[board as BoardType].path;
+  return <PostEdit boardName={boardName} boardId={boardId} postId={Number(postId)} path={path} />;
+}

--- a/src/features/post/ui/PostKebabButton.tsx
+++ b/src/features/post/ui/PostKebabButton.tsx
@@ -2,8 +2,11 @@
 
 import React, { useEffect, useRef, useState } from 'react';
 import { Delete, Write } from './icons';
+import Link from 'next/link';
+import { usePathname } from 'next/navigation';
 
 export default function PostKebabButton() {
+  const pathname = usePathname();
   const [dropMenuOpen, setDropMenuOpen] = useState<boolean>(false);
 
   const dropMenuButtonRep = useRef<HTMLSpanElement>(null);
@@ -44,9 +47,13 @@ export default function PostKebabButton() {
           ref={dropMenuRep}
           className="absolute right-0 z-10 mt-2 flex h-fit w-[12.5rem] flex-col gap-y-1 rounded-[1.25rem] bg-white p-4 shadow-[0px_2px_10px_0px_rgba(0,_0,_0,_0.08)]"
         >
-          <span className="flex h-11 w-full cursor-pointer items-center gap-x-1.5 rounded-xl p-2 text-md font-medium text-gray-800 hover:bg-gray-100">
-            <Write /> <span>게시글 수정</span>
-          </span>
+          <Link
+            href={`${pathname}/edit`}
+            className="flex h-11 w-full cursor-pointer items-center gap-x-1.5 rounded-xl p-2 text-md font-medium text-gray-800 hover:bg-gray-100"
+          >
+            <Write />
+            <span>게시글 수정</span>
+          </Link>
           <span className="flex h-11 w-full cursor-pointer items-center gap-x-1.5 rounded-xl p-2 text-md font-medium text-negative hover:bg-gray-100">
             <Delete /> <span>게시글 삭제</span>
           </span>

--- a/src/features/write/lib/extractImageIdsFromDelta.ts
+++ b/src/features/write/lib/extractImageIdsFromDelta.ts
@@ -1,0 +1,17 @@
+import type { Delta } from 'quill';
+
+/**
+ * Quill Delta 객체에서 customImage 블롯의 이미지 ID만 추출하여 배열로 반환합니다.
+ */
+export function extractImageIdsFromDelta(delta: Delta): number[] {
+  const ids: number[] = [];
+  delta.ops.forEach((op) => {
+    if (typeof op.insert === 'object' && op.insert !== null) {
+      const insert = op.insert as { customImage?: { id: string | number } };
+      if (insert.customImage?.id) {
+        ids.push(Number(insert.customImage.id));
+      }
+    }
+  });
+  return ids;
+}

--- a/src/features/write/lib/index.ts
+++ b/src/features/write/lib/index.ts
@@ -1,0 +1,3 @@
+import { extractImageIdsFromDelta } from './extractImageIdsFromDelta';
+
+export { extractImageIdsFromDelta };

--- a/src/features/write/ui/PostEdit.tsx
+++ b/src/features/write/ui/PostEdit.tsx
@@ -1,0 +1,81 @@
+'use client';
+import Write from './Write';
+import { axiosPost, axiosUpdatePost } from '@/shared/api';
+import { useUserStore } from '@/shared/store';
+import { PostDetailResponse, RichTextEditorHandle } from '@/shared/types';
+import { useRouter } from 'next/navigation';
+import { useEffect, useRef } from 'react';
+import { extractImageIdsFromDelta } from '../lib';
+import { useQuery } from '@tanstack/react-query';
+
+interface postEditeProps {
+  /** 게시판 이름 */
+  boardName: string;
+  /** 게시판 id */
+  boardId: number;
+  /** 게시물 id */
+  postId: number;
+  /** path */
+  path: string;
+}
+
+const PostEdit = ({ boardName, boardId, postId, path }: postEditeProps) => {
+  const router = useRouter();
+  const { jwt } = useUserStore();
+  const editorRef = useRef<RichTextEditorHandle>(null); // 에디터 내용(DOM)이나 메서드에 접근하기 위한 ref
+  const titleRef = useRef<HTMLInputElement>(null); // 제목 저장하는 ref
+  const originalImageIdsRef = useRef<number[]>([]); // 수정 전 에디터에 포함된 이미지 ID 목록 저장용
+
+  const { data } = useQuery({
+    queryKey: ['postDetail', boardId, postId],
+    queryFn: () => axiosPost<PostDetailResponse>(boardId, postId),
+  });
+  const post = data?.postInfoDto;
+  const images = data?.imageInfos;
+
+  const handleSubmit = async () => {
+    const title = titleRef.current?.value.trim();
+    const delta = editorRef.current?.getContents();
+    if (!title || !delta) {
+      return alert('제목 또는 내용을 입력해주세요');
+    }
+    const content = JSON.stringify(delta);
+    // 현재 Delta에서 추출한 이미지 ID 목록
+    const newImageIdList = extractImageIdsFromDelta(delta);
+    const deleteImageIdList = originalImageIdsRef.current.filter(
+      (id) => !newImageIdList.includes(id)
+    );
+
+    if (!jwt) {
+      // 로그인 안 된 상태이므로 요청 중단
+      return;
+    }
+    await axiosUpdatePost(jwt, boardId, postId, title, content, newImageIdList, deleteImageIdList);
+    router.push(`${path}`);
+  };
+
+  // post 데이터가 로드되면 제목 input과 이미지 ID 초기값 설정
+  useEffect(() => {
+    // 제목 초기값 설정
+    if (post && titleRef.current) {
+      titleRef.current.value = post.title;
+    }
+
+    // 이미지 ID 초기값 저장
+    if (images) {
+      originalImageIdsRef.current = images.map((img) => img.id);
+    }
+  }, [post, images]);
+
+  return (
+    <Write
+      boardName={boardName}
+      titleRef={titleRef}
+      editorRef={editorRef}
+      onSubmit={handleSubmit}
+      initialDelta={post?.content ? JSON.parse(post.content) : undefined}
+    />
+  );
+};
+
+export default PostEdit;

--- a/src/features/write/ui/PostWrite.tsx
+++ b/src/features/write/ui/PostWrite.tsx
@@ -1,11 +1,11 @@
 'use client';
+import { extractImageIdsFromDelta } from '../lib';
 import Write from './Write';
 import { axiosUploadPost } from '@/shared/api';
 import { useUserStore } from '@/shared/store';
 import { RichTextEditorHandle } from '@/shared/types';
 import { useRouter } from 'next/navigation';
 import { useRef } from 'react';
-import type { Delta } from 'quill';
 
 interface PostWriteProps {
   /** 게시판 이름 */
@@ -21,21 +21,6 @@ const PostWrite = ({ boardName, boardId, path }: PostWriteProps) => {
   const { jwt } = useUserStore();
   const editorRef = useRef<RichTextEditorHandle>(null); // 에디터 내용(DOM)이나 메서드에 접근하기 위한 ref
   const titleRef = useRef<HTMLInputElement>(null); // 제목 저장하는 ref
-
-  // Delta에서 img id 추출함수
-  const extractImageIdsFromDelta = (delta: Delta): number[] => {
-    const ids: number[] = [];
-    delta.ops.forEach((op) => {
-      if (typeof op.insert === 'object' && op.insert !== null) {
-        const insert = op.insert as { customImage?: { id: string | number } };
-        if (insert.customImage?.id) {
-          ids.push(Number(insert.customImage.id));
-        }
-      }
-    });
-
-    return ids;
-  };
 
   const handleSubmit = async () => {
     const title = titleRef.current?.value;

--- a/src/features/write/ui/RichTextEditor.tsx
+++ b/src/features/write/ui/RichTextEditor.tsx
@@ -8,102 +8,113 @@ import { ImageUploadResponse, RichTextEditorHandle } from '@/shared/types';
 import { useUserStore } from '@/shared/store';
 import '../lib/customImageBlot';
 
-const RichTextEditor = forwardRef<RichTextEditorHandle>((_, ref) => {
-  const { jwt } = useUserStore();
-  const editorRef = useRef<HTMLDivElement>(null); // 에디터 컨테이너
-  const quillRef = useRef<Quill | null>(null); // Quill 인스턴스
+interface RichTextEditorProps {
+  /** 글 수정 시 에디터에 미리 채워 넣을 초기 Delta 데이터 */
+  initialDelta?: Delta;
+}
 
-  const imageHandler = useCallback(
-    (editor: Quill) => {
-      // 파일 입력창 생성
-      const input = document.createElement('input');
-      input.setAttribute('type', 'file');
-      input.setAttribute('accept', 'image/*');
-      input.setAttribute('name', 'file');
-      input.setAttribute('multiple', '');
-      input.click();
+const RichTextEditor = forwardRef<RichTextEditorHandle, RichTextEditorProps>(
+  ({ initialDelta }, ref) => {
+    const { jwt } = useUserStore();
+    const editorRef = useRef<HTMLDivElement>(null); // 에디터 컨테이너
+    const quillRef = useRef<Quill | null>(null); // Quill 인스턴스
 
-      // 파일 선택 후 이벤트 처리
-      input.onchange = async (event: Event) => {
-        const target = event.target as HTMLInputElement;
-        const files = target.files;
-        if (!files || files.length === 0) return;
+    const imageHandler = useCallback(
+      (editor: Quill) => {
+        // 파일 입력창 생성
+        const input = document.createElement('input');
+        input.setAttribute('type', 'file');
+        input.setAttribute('accept', 'image/*');
+        input.setAttribute('name', 'file');
+        input.setAttribute('multiple', '');
+        input.click();
 
-        const formData = new FormData();
-        for (let i = 0; i < files.length; i++) {
-          formData.append('images', files[i]);
-        }
+        // 파일 선택 후 이벤트 처리
+        input.onchange = async (event: Event) => {
+          const target = event.target as HTMLInputElement;
+          const files = target.files;
+          if (!files || files.length === 0) return;
 
-        if (!jwt) {
-          // 로그인 안 된 상태이므로 요청 중단
-          return;
-        }
+          const formData = new FormData();
+          for (let i = 0; i < files.length; i++) {
+            formData.append('images', files[i]);
+          }
 
-        //  S3 업로드 요청
-        const response = await axiosUploadImages<ImageUploadResponse>(jwt, formData); // 다중 파일
+          if (!jwt) {
+            // 로그인 안 된 상태이므로 요청 중단
+            return;
+          }
 
-        // Quill 에디터에 <img> 태그 추가
-        response?.imageUploadDto.forEach((img) => {
-          const range = editor.getSelection()!;
-          editor.insertEmbed(range.index, 'customImage', {
-            url: img.imageUrl,
-            id: img.id,
+          //  S3 업로드 요청
+          const response = await axiosUploadImages<ImageUploadResponse>(jwt, formData); // 다중 파일
+
+          // Quill 에디터에 <img> 태그 추가
+          response?.imageUploadDto.forEach((img) => {
+            const range = editor.getSelection()!;
+            editor.insertEmbed(range.index, 'customImage', {
+              url: img.imageUrl,
+              id: img.id,
+            });
+            editor.setSelection(range.index + 1);
           });
-          editor.setSelection(range.index + 1);
-        });
-      };
-    },
-    [jwt]
-  );
+        };
+      },
+      [jwt]
+    );
 
-  useEffect(() => {
-    // 에디터 DOM이 아직 렌더링되지 않은 경우 실행하지 않음
-    if (!editorRef.current) return;
+    useEffect(() => {
+      // 에디터 DOM이 아직 렌더링되지 않은 경우 실행하지 않음
+      if (!editorRef.current) return;
 
-    // Quill이 이미 초기화된 경우 중복 초기화를 방지
-    if (quillRef.current) return;
+      // Quill이 이미 초기화된 경우 중복 초기화를 방지
+      if (quillRef.current) return;
 
-    const quill = new Quill(editorRef.current, {
-      theme: 'snow',
-      placeholder: '내용을 입력하세요.',
-      modules: {
-        toolbar: {
-          container: [
-            [{ header: [1, 2, 3, false] }],
-            ['bold', 'italic', 'underline', 'strike'],
-            [{ list: 'ordered' }, { list: 'bullet' }],
-            ['link', 'image'],
-          ],
-          handlers: {
-            image: () => {
-              imageHandler(quill);
+      const quill = new Quill(editorRef.current, {
+        theme: 'snow',
+        placeholder: '내용을 입력하세요.',
+        modules: {
+          toolbar: {
+            container: [
+              [{ header: [1, 2, 3, false] }],
+              ['bold', 'italic', 'underline', 'strike'],
+              [{ list: 'ordered' }, { list: 'bullet' }],
+              ['link', 'image'],
+            ],
+            handlers: {
+              image: () => {
+                imageHandler(quill);
+              },
             },
           },
         },
-      },
-    });
+      });
 
-    quillRef.current = quill;
+      quillRef.current = quill;
 
-    // quill.on('text-change', () => {
-    //   console.log('Text change!');
-    // });
+      // quill.on('text-change', () => {
+      //   console.log('Text change!');
+      // });
 
-    // return () => {
-    //   quillRef.current = null; // Cleanup to avoid memory leaks
-    // };
-  }, [imageHandler]);
+      // return () => {
+      //   quillRef.current = null; // Cleanup to avoid memory leaks
+      // };
+    }, [imageHandler]);
 
-  // 부모 컴포넌트가 getContents 함수를 사용할 수 있도록 연결한다
-  useImperativeHandle(ref, () => ({
-    getContents: () => quillRef.current?.getContents() ?? new Delta(),
-    setContents: (delta: Delta) => {
-      quillRef.current?.setContents(delta, 'api');
-    },
-  }));
+    // 부모 컴포넌트가 getContents 함수를 사용할 수 있도록 연결한다
+    useImperativeHandle(ref, () => ({
+      getContents: () => quillRef.current?.getContents() ?? new Delta(),
+    }));
 
-  return <div ref={editorRef} style={{ height: '300px' }} />;
-});
+    // 초기 Delta 데이터가 있을 경우 에디터에 주입
+    useEffect(() => {
+      if (initialDelta && quillRef.current) {
+        quillRef.current.setContents(initialDelta, 'api');
+      }
+    }, [initialDelta]);
+
+    return <div ref={editorRef} style={{ height: '300px' }} />;
+  }
+);
 
 RichTextEditor.displayName = 'RichTextEditor';
 

--- a/src/features/write/ui/Write.tsx
+++ b/src/features/write/ui/Write.tsx
@@ -5,6 +5,7 @@ import { RichTextEditorHandle } from '@/shared/types';
 import { InputFieldTitle, PrimaryButton } from '@/shared/ui';
 import dynamic from 'next/dynamic';
 import Image from 'next/image';
+import type { Delta } from 'quill';
 import type { RefObject } from 'react';
 
 // Quill이 SSR 중 로딩되지 않도록 방지
@@ -23,6 +24,8 @@ interface WriteProps {
   editorRef: RefObject<RichTextEditorHandle | null>;
   /** 게시글 등록 또는 수정 버튼 클릭 시 호출되는 함수 (추후 옵셔널 삭제)*/
   onSubmit: () => void;
+  /** 글 수정 시 에디터에 미리 채워 넣을 초기 Delta 데이터 */
+  initialDelta?: Delta;
 }
 
 export default function Write({
@@ -30,6 +33,7 @@ export default function Write({
   isHotBoard = false,
   titleRef,
   editorRef,
+  initialDelta,
   onSubmit,
 }: WriteProps) {
   return (
@@ -69,7 +73,7 @@ export default function Write({
             <div className="flex flex-col gap-y-1">
               <span className="text-xs font-regular text-gray-800">내용</span>
               <div>
-                <RichTextEditor ref={editorRef} />
+                <RichTextEditor ref={editorRef} initialDelta={initialDelta} />
               </div>
             </div>
           </div>

--- a/src/features/write/ui/index.ts
+++ b/src/features/write/ui/index.ts
@@ -1,3 +1,4 @@
+import PostEdit from './PostEdit';
 import PostWrite from './PostWrite';
 
-export { PostWrite };
+export { PostWrite, PostEdit };

--- a/src/shared/api/axios/axios.ts
+++ b/src/shared/api/axios/axios.ts
@@ -136,6 +136,31 @@ export const axiosUploadPost = async <T>(
     }
   );
 
+export const axiosUpdatePost = async <T>(
+  accessToken: string,
+  boardId: number,
+  postId: number,
+  title: string,
+  content: string,
+  newImageIdList: number[],
+  deleteImageIdList: number[]
+): Promise<T> => {
+  return await axiosInstance.put(
+    `/api/v1/boards/${boardId}/posts/${postId}`,
+    {
+      title,
+      content,
+      newImageIdList,
+      deleteImageIdList,
+    },
+    {
+      headers: {
+        Authorization: `Bearer ${accessToken}`,
+      },
+    }
+  );
+};
+
 // [2025-06-11 이동규] 댓글 작성 추후 추가
 
 export const axiosScrapPost = async <T>(

--- a/src/shared/api/index.ts
+++ b/src/shared/api/index.ts
@@ -20,6 +20,7 @@ import {
   axiosUploadPost,
   axiosUserProfile,
   axiosGetAutocomplete,
+  axiosUpdatePost,
 } from './axios/axios';
 
 export {
@@ -44,4 +45,5 @@ export {
   axiosUploadPost,
   axiosUserProfile,
   axiosGetAutocomplete,
+  axiosUpdatePost,
 };

--- a/src/shared/types/post.ts
+++ b/src/shared/types/post.ts
@@ -22,6 +22,7 @@ export interface PostInfo {
 export interface PostDetailResponse {
   message: string;
   postInfoDto: PostDetail;
+  imageInfos: ImageInfo[];
 }
 
 export interface PostDetail {

--- a/src/shared/types/write.ts
+++ b/src/shared/types/write.ts
@@ -2,5 +2,4 @@ import { Delta } from 'quill';
 
 export type RichTextEditorHandle = {
   getContents: () => Delta;
-  setContents: (delta: Delta) => void;
 };

--- a/src/widgets/post/ui/Content.tsx
+++ b/src/widgets/post/ui/Content.tsx
@@ -21,7 +21,6 @@ export default function Content({ post }: { post: PostDetail }) {
       return '';
     });
     html = converter.convert();
-    console.log(html);
   } catch {
     html = post.content;
   }


### PR DESCRIPTION
## 변경 사항
- extractImageIdsFromDelta 함수 분리 (write/lib로)
- PostKebabButton에 게시글 수정 페이지 이동 기능 추가
- 게시글 수정용 API 요청 함수 axiosUpdatePost 추가
- 게시글 수정 기능 구현 (Delta 기반 데이터 업데이트)

## 세부 설명
- 에디터 내 이미지 ID 추출 로직을 별도 유틸 함수로 분리하였습니다.
- 게시글 수정 버튼 클릭 시 현재 경로 + /edit로 이동하는 로직을 PostKebabButton에 추가했습니다.
- 수정 요청 시 기존 이미지 ID와 현재 이미지 ID를 비교해 삭제된 이미지 ID 목록도 함께 서버에 전달합니다.

## 관련 이슈

## 스크린샷 (선택 사항)


## 테스트 방법

## 체크리스트
- [x] 코드가 프로젝트의 코딩 스타일을 준수합니다
- [x] 자체 코드 리뷰를 수행했습니다
- [ ] 변경 사항에 대한 테스트가 추가/수정되었습니다
- [ ] 모든 테스트가 통과합니다
- [ ] 필요한 문서를 업데이트했습니다
