### PR TITLE
[FEAT] 게시물 삭제 로직 구현

### DIFF
--- a/src/features/post/ui/PostKebabButton.tsx
+++ b/src/features/post/ui/PostKebabButton.tsx
@@ -1,7 +1,43 @@
+'use client';
+
+import { useParams, useRouter } from 'next/navigation';
 import { Delete, Write } from './icons';
 import { Dropdownmenu, Kebab32 } from '@/shared/ui';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { axiosDeletePost } from '@/shared/api';
+import { BOARD_MAP } from '@/shared/constants';
+import type { BoardType } from '@/shared/types';
 
 export default function PostKebabButton() {
+  const queryClient = useQueryClient();
+  const router = useRouter();
+  const { board, postId } = useParams();
+  const boardId = BOARD_MAP[board as BoardType].id;
+
+  const { mutate: deletePost } = useMutation({
+    mutationFn: ({ boardId, postId }: { boardId: number; postId: number }) =>
+      axiosDeletePost(boardId, postId),
+    onSuccess: () => {
+      alert('게시글이 삭제되었습니다.');
+      queryClient.invalidateQueries({
+        queryKey: ['posts', boardId, 1],
+      });
+      router.push(`/${board}`);
+    },
+    onError: () => {
+      alert('삭제 실패');
+    },
+  });
+
+  // 편집 로직
+  const handleEdit = () => {
+    router.push(`/${board}/post/${postId}/edit`);
+  };
+
+  // 삭제 로직
+  const handleDelete = () => {
+    deletePost({ boardId, postId: Number(postId as string) });
+  };
   return (
     <Dropdownmenu
       trigger={
@@ -17,6 +53,7 @@ export default function PostKebabButton() {
               <span>게시글 수정</span>
             </>
           ),
+          onClick: handleEdit,
         },
         {
           content: (
@@ -25,6 +62,7 @@ export default function PostKebabButton() {
               <span className="text-negative">게시글 삭제</span>
             </>
           ),
+          onClick: handleDelete,
         },
       ]}
     />

--- a/src/shared/api/axios/axios.ts
+++ b/src/shared/api/axios/axios.ts
@@ -134,6 +134,10 @@ export const axiosUpdatePost = async <T>(
   });
 };
 
+export const axiosDeletePost = async <T>(boardId: number, postId: number): Promise<T> => {
+  return await axiosInstance.delete(`/api/v1/boards/${boardId}/posts/${postId}`);
+};
+
 // [2025-06-11 이동규] 댓글 작성 추후 추가
 
 export const axiosScrapPost = async <T>(boardId: number, postId: number): Promise<T> =>

--- a/src/shared/api/index.ts
+++ b/src/shared/api/index.ts
@@ -21,6 +21,7 @@ import {
   axiosUserProfile,
   axiosGetAutocomplete,
   axiosUpdatePost,
+  axiosDeletePost,
 } from './axios/axios';
 
 export {
@@ -46,4 +47,5 @@ export {
   axiosUserProfile,
   axiosGetAutocomplete,
   axiosUpdatePost,
+  axiosDeletePost,
 };


### PR DESCRIPTION
## 변경 사항
- 게시글 삭제 API 연동 추가
- 게시물 수정 버튼 클릭 시 `/${board}/post/${postId}/edit` 경로로 이동하도록 처리
- 게시물 삭제 버튼 클릭 시 게시글 삭제 후 목록 페이지로 이동 및 캐시 무효화 처리

## 세부 설명
.

## 관련 이슈
.

## 스크린샷 (선택 사항)
.


## 테스트 방법
.

## 체크리스트
- [x] 코드가 프로젝트의 코딩 스타일을 준수합니다
- [x] 자체 코드 리뷰를 수행했습니다
- [ ] 변경 사항에 대한 테스트가 추가/수정되었습니다
- [ ] 모든 테스트가 통과합니다
- [ ] 필요한 문서를 업데이트했습니다
