### PR TITLE
[feat] 게시글 목록 쿼리에 keepPreviousData 적용 및 postNumber → postId 변경

### DIFF
--- a/src/entities/board/ui/BoardList.tsx
+++ b/src/entities/board/ui/BoardList.tsx
@@ -1,27 +1,16 @@
 import { PostInfo } from '@/shared/types';
 import BoardRow from './BoardRow';
-import { BOARD_PAGE_SIZE } from '@/shared/constants';
 
 interface BoardListProps {
   /** 전체 게시글 정보 */
   posts: PostInfo[];
-  /** 전체 게시물 수 */
-  totalCount: number;
-  /** 현재 페이지 */
-  page: number;
   /** 링크 prefix 명시 */
   basePath: string;
   /** 번호 표시 여부 (기본값 true) */
   showNumber?: boolean;
 }
 
-export default function BoardList({
-  posts,
-  totalCount,
-  page,
-  basePath,
-  showNumber,
-}: BoardListProps) {
+export default function BoardList({ posts, basePath, showNumber }: BoardListProps) {
   return (
     <div className="flex flex-col gap-y-2">
       <div className="flex justify-between gap-2 border-b border-gray-200 px-2 pb-3 text-center text-sm text-gray-500">
@@ -52,18 +41,9 @@ export default function BoardList({
           />
         ))} */}
 
-      {posts.map((post, index) => {
-        const postNumber = totalCount - (page - 1) * BOARD_PAGE_SIZE - index;
-        return (
-          <BoardRow
-            key={post.postId}
-            post={post}
-            postNumber={postNumber}
-            basePath={basePath}
-            showNumber={showNumber}
-          />
-        );
-      })}
+      {posts.map((post) => (
+        <BoardRow key={post.postId} post={post} basePath={basePath} showNumber={showNumber} />
+      ))}
     </div>
   );
 }

--- a/src/entities/board/ui/BoardRow.tsx
+++ b/src/entities/board/ui/BoardRow.tsx
@@ -21,8 +21,6 @@ interface BoardRowProps {
   post: PostInfo;
   /** 게시글 종류 */
   type?: 'noti' | 'issue' | 'normal';
-  /** 전체 게시글 기준 번호 */
-  postNumber: number;
   /** 링크 prefix 명시 */
   basePath: string;
   /** 번호 표시 여부 (기본값 true) */
@@ -32,7 +30,6 @@ interface BoardRowProps {
 export default function BoardRow({
   post,
   type = 'normal',
-  postNumber,
   basePath,
   showNumber = true,
 }: BoardRowProps) {
@@ -47,7 +44,7 @@ export default function BoardRow({
       <div className="flex items-center gap-2">
         {/* 번호 */}
         {showNumber && (
-          <div className="w-12 text-center text-sm font-regular text-gray-500">{postNumber}</div>
+          <div className="w-12 text-center text-sm font-regular text-gray-500">{post.postId}</div>
         )}
         {getBadge()}
         <div className="flex items-center gap-x-1.5">

--- a/src/features/board/ui/BoardSection.tsx
+++ b/src/features/board/ui/BoardSection.tsx
@@ -4,7 +4,7 @@ import { axiosPosts } from '@/shared/api';
 import { BOARD_PAGE_SIZE } from '@/shared/constants';
 import { PostListResponse } from '@/shared/types';
 import { Pagination } from '@/shared/ui';
-import { useQuery } from '@tanstack/react-query';
+import { keepPreviousData, useQuery } from '@tanstack/react-query';
 import { useState } from 'react';
 
 interface BoardSectionProps {
@@ -16,19 +16,14 @@ const BoardSection = ({ boardId }: BoardSectionProps) => {
   const { data } = useQuery({
     queryKey: ['posts', boardId, page],
     queryFn: () => axiosPosts<PostListResponse>(boardId, page, BOARD_PAGE_SIZE),
+    placeholderData: keepPreviousData,
   });
 
   if (!data) return null;
 
   return (
     <div className="flex flex-col gap-8">
-      <BoardList
-        posts={data.postsListDto}
-        totalCount={data.totalCount}
-        page={page}
-        basePath={`/board/${boardId}`}
-        showNumber
-      />
+      <BoardList posts={data.postsListDto} basePath={`/board/${boardId}`} showNumber />
       <Pagination currentPage={page} maxPage={data.totalPageCount} count={5} setPage={setPage} />
     </div>
   );

--- a/src/views/hotBoards/ui/HotBoard.tsx
+++ b/src/views/hotBoards/ui/HotBoard.tsx
@@ -100,12 +100,7 @@ export default function HotBoard({ boardId }: HotBoardProps) {
             </span>
           </PrimaryButton>
         </div>
-        <BoardList
-          posts={posts.postsListDto}
-          totalCount={posts.totalCount}
-          page={1}
-          basePath={`/hotboard/${boardId}`}
-        />
+        <BoardList posts={posts.postsListDto} basePath={`/hotboard/${boardId}`} />
         <Pagination
           currentPage={page}
           maxPage={posts.totalPageCount || 1}

--- a/src/widgets/search/ui/FixedBoardsSection.tsx
+++ b/src/widgets/search/ui/FixedBoardsSection.tsx
@@ -75,13 +75,7 @@ const FixedBoardsSection = ({ keyword }: FixedBoardsSectionProps) => {
         />
       ) : (
         <>
-          <BoardList
-            posts={postData.postList}
-            totalCount={postData.totalCount}
-            page={page}
-            basePath={`/${currentTab}`}
-            showNumber={false}
-          />
+          <BoardList posts={postData.postList} basePath={`/${currentTab}`} showNumber={false} />
           <Pagination
             currentPage={page}
             maxPage={postData.totalPageCount}


### PR DESCRIPTION
## 변경 사항
- 게시글 목록 쿼리에 keepPreviousData 적용 및 postNumber → postId 변경

## 세부 설명
- keepPreviousData를 설정하여 페이지 전환 시 기존 데이터가 사라지지 않고 유지되도록 개선

## 관련 이슈
.

## 스크린샷 (선택 사항)
<img width="3456" height="2418" alt="image" src="https://github.com/user-attachments/assets/a7305e16-6472-40e3-a596-a765c78f0803" />


## 테스트 방법
.

## 체크리스트
- [x] 코드가 프로젝트의 코딩 스타일을 준수합니다
- [x] 자체 코드 리뷰를 수행했습니다
- [ ] 변경 사항에 대한 테스트가 추가/수정되었습니다
- [ ] 모든 테스트가 통과합니다
- [ ] 필요한 문서를 업데이트했습니다
