### PR TITLE
[REFACTOR] DropdownMenu 컴포넌트를 선언형 구조로 리팩토링

### DIFF
--- a/src/features/post/ui/CommentKebabButton.tsx
+++ b/src/features/post/ui/CommentKebabButton.tsx
@@ -1,7 +1,7 @@
 import { Delete, Write } from '@/features/post/ui/icons';
 import { axiosDeleteComment } from '@/shared/api';
 import { InternalServerError } from '@/shared/error/error';
-import { Dropdownmenu, Kebab32 } from '@/shared/ui';
+import { DropdownMenu, DropdownMenuItem, Kebab32 } from '@/shared/ui';
 
 interface CommentKebabButtonProps {
   /**@param {number} boardId 게시판 아이디 */
@@ -44,32 +44,21 @@ export default function CommentKebabButton({
   };
 
   return (
-    <Dropdownmenu
+    <DropdownMenu
       trigger={
         <span className="flex h-8 w-8 items-center justify-center rounded-lg hover:bg-gray-200">
           <Kebab32 />
         </span>
       }
-      items={[
-        {
-          content: (
-            <>
-              <Write />
-              <span>댓글 수정</span>
-            </>
-          ),
-          onClick: onEditClick,
-        },
-        {
-          content: (
-            <>
-              <Delete />
-              <span className="text-negative">댓글 삭제</span>
-            </>
-          ),
-          onClick: handleDeleteComment,
-        },
-      ]}
-    />
+    >
+      <DropdownMenuItem onClick={onEditClick}>
+        <Write />
+        댓글 수정
+      </DropdownMenuItem>
+      <DropdownMenuItem onClick={handleDeleteComment} className="text-negative">
+        <Delete />
+        댓글 삭제
+      </DropdownMenuItem>
+    </DropdownMenu>
   );
 }

--- a/src/features/post/ui/PostKebabButton.tsx
+++ b/src/features/post/ui/PostKebabButton.tsx
@@ -2,7 +2,7 @@
 
 import { useParams, usePathname, useRouter } from 'next/navigation';
 import { Delete, Write } from './icons';
-import { Dropdownmenu, Kebab32 } from '@/shared/ui';
+import { DropdownMenu, DropdownMenuItem, Kebab32 } from '@/shared/ui';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { axiosDeletePost } from '@/shared/api';
 
@@ -40,32 +40,21 @@ export default function PostKebabButton() {
     deletePost({ boardId: Number(boardId), postId: Number(postId) });
   };
   return (
-    <Dropdownmenu
+    <DropdownMenu
       trigger={
         <span className="flex h-10 w-10 items-center justify-center rounded-lg border border-gray-200">
           <Kebab32 className="text-gray-500" />
         </span>
       }
-      items={[
-        {
-          content: (
-            <>
-              <Write />
-              <span>게시글 수정</span>
-            </>
-          ),
-          onClick: handleEdit,
-        },
-        {
-          content: (
-            <>
-              <Delete />
-              <span className="text-negative">게시글 삭제</span>
-            </>
-          ),
-          onClick: handleDelete,
-        },
-      ]}
-    />
+    >
+      <DropdownMenuItem onClick={handleEdit}>
+        <Write />
+        게시물 수정
+      </DropdownMenuItem>
+      <DropdownMenuItem onClick={handleDelete} className="text-negative">
+        <Delete />
+        게시물 삭제
+      </DropdownMenuItem>
+    </DropdownMenu>
   );
 }

--- a/src/shared/ui/buttons/DropdownMenuItem.tsx
+++ b/src/shared/ui/buttons/DropdownMenuItem.tsx
@@ -1,0 +1,34 @@
+import { cn } from '@/shared/lib';
+
+interface DropdownMenuItemProps {
+  /** 메뉴 항목에 표시될 내용 */
+  children: React.ReactNode;
+
+  /** 메뉴 항목 클릭 시 실행할 콜백 */
+  // 옵셔널 추후 삭제
+  onClick?: () => void;
+
+  /** 추가로 적용할 클래스명 (선택) */
+  className?: string;
+}
+
+export default function DropdownMenuItem({
+  children,
+
+  onClick,
+  className,
+}: DropdownMenuItemProps) {
+  return (
+    <li>
+      <button
+        className={cn(
+          'flex h-11 w-full cursor-pointer items-center gap-1.5 rounded-xl p-2 text-md font-medium text-gray-800 hover:bg-gray-100',
+          className
+        )}
+        onClick={onClick}
+      >
+        {children}
+      </button>
+    </li>
+  );
+}

--- a/src/shared/ui/buttons/Dropdownmenu.tsx
+++ b/src/shared/ui/buttons/Dropdownmenu.tsx
@@ -1,12 +1,19 @@
 'use client';
+import { cn } from '@/shared/lib';
 import { useEffect, useRef, useState } from 'react';
 
-interface DropdownmenuProps {
-  trigger: React.ReactNode; // 드롭다운을 여는 버튼
-  items: DropdownMenuItemProps[]; // 드롭다운 메뉴 항목 목록
+interface DropdownMenuProps {
+  /** 드롭다운을 여는 트리거 요소 */
+  trigger: React.ReactNode;
+
+  /** 드롭다운 내부에 표시될 콘텐츠 (메뉴 항목 등) */
+  children: React.ReactNode;
+
+  /** 드롭다운 wrapper에 적용할 클래스명 */
+  className?: string;
 }
 
-const Dropdownmenu = ({ trigger, items }: DropdownmenuProps) => {
+const DropdownMenu = ({ trigger, className, children }: DropdownMenuProps) => {
   const [dropMenuOpen, setDropMenuOpen] = useState<boolean>(false); // 메뉴 열림 상태
 
   const buttonRef = useRef<HTMLButtonElement>(null); // 트리거 버튼 ref
@@ -45,34 +52,16 @@ const Dropdownmenu = ({ trigger, items }: DropdownmenuProps) => {
       {dropMenuOpen && (
         <ul
           ref={menuRef}
-          className="absolute right-0 z-10 mt-2 flex w-[10rem] flex-col gap-y-1 rounded-xl bg-white p-3 shadow-[0px_2px_10px_0px_rgba(0,_0,_0,_0.08)]"
+          className={cn(
+            'absolute right-0 z-10 mt-2 flex w-[10rem] flex-col gap-y-1 rounded-xl bg-white p-3 shadow-[0px_2px_10px_0px_rgba(0,_0,_0,_0.08)]',
+            className
+          )}
         >
-          {items.map((item, idx) => (
-            <DropdownMenuItem key={idx} {...item} />
-          ))}
+          {children}
         </ul>
       )}
     </div>
   );
 };
 
-export default Dropdownmenu;
-
-interface DropdownMenuItemProps {
-  content: React.ReactNode;
-  // 추후 옵셔널 제거
-  onClick?: () => void;
-}
-
-const DropdownMenuItem = ({ content, onClick }: DropdownMenuItemProps) => {
-  return (
-    <li>
-      <button
-        className="flex h-11 w-full cursor-pointer items-center gap-1.5 rounded-xl p-2 text-md font-medium text-gray-800 hover:bg-gray-100"
-        onClick={onClick}
-      >
-        {content}
-      </button>
-    </li>
-  );
-};
+export default DropdownMenu;

--- a/src/shared/ui/index.ts
+++ b/src/shared/ui/index.ts
@@ -4,7 +4,8 @@ import { DropdownChip, DropdownChipItem } from './buttons/DropdownChip';
 import Pagination from './pagination/Pagination';
 import PrimaryButton from './buttons/PrimaryButton';
 import SecondaryButton from './buttons/SecondaryButton';
-import Dropdownmenu from './buttons/Dropdownmenu';
+import DropdownMenu from './buttons/DropdownMenu';
+import DropdownMenuItem from './buttons/DropdownMenuItem';
 
 /** Dividers */
 import DateDivider from './divider/DateDivider';
@@ -57,7 +58,8 @@ export {
   Pagination,
   PrimaryButton,
   SecondaryButton,
-  Dropdownmenu,
+  DropdownMenu,
+  DropdownMenuItem,
   DateDivider,
   InformationOutlined16,
   Comment18,


### PR DESCRIPTION
## 변경 사항
- DropdownMenu 컴포넌트를 기존 props 기반에서 children 선언형 구조로 변경

## 세부 설명
이번 변경으로 DropdownMenu는 아래처럼 선언형 구조로 사용할 수 있습니다:

```tsx
<DropdownMenu
  trigger={
    <span className="flex h-10 w-10 items-center justify-center rounded-lg border border-gray-200">
      <Kebab32 className="text-gray-500" />
    </span>
  }
>
  <DropdownMenuItem onClick={handleEdit}>
    <Write />
    게시물 수정
  </DropdownMenuItem>

  <DropdownMenuItem onClick={handleDelete} className="text-negative">
    <Delete />
    게시물 삭제
  </DropdownMenuItem>
</DropdownMenu>

## 관련 이슈
.

## 스크린샷 (선택 사항)
.


## 테스트 방법
변경 사항을 테스트하는 방법에 대한 설명

## 체크리스트
- [x] 코드가 프로젝트의 코딩 스타일을 준수합니다
- [x] 자체 코드 리뷰를 수행했습니다
- [ ] 변경 사항에 대한 테스트가 추가/수정되었습니다
- [ ] 모든 테스트가 통과합니다
- [ ] 필요한 문서를 업데이트했습니다
