### PR TITLE
[FEAT] 포털 기반 Modal 컴포넌트 추가

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -35,6 +35,7 @@ export default function RootLayout({
     >
       <body className="relative font-pretendard antialiased">
         <QueryProvider>{children}</QueryProvider>
+        <div id="modal-root" />
       </body>
     </html>
   );

--- a/src/features/login/ui/LoginModal.tsx
+++ b/src/features/login/ui/LoginModal.tsx
@@ -4,6 +4,7 @@ import Image from 'next/image';
 import React from 'react';
 import { Close } from './icons';
 import { usePathname } from 'next/navigation';
+import { Modal } from '@/shared/ui';
 
 interface LoginModalProps extends React.RefAttributes<HTMLDivElement> {
   /**@param {boolean} open 모달 여닫음 여부 */
@@ -12,7 +13,7 @@ interface LoginModalProps extends React.RefAttributes<HTMLDivElement> {
   onClose: () => void;
 }
 
-export default function LoginModal({ open, onClose, ref }: LoginModalProps) {
+export default function LoginModal({ open, onClose }: LoginModalProps) {
   const pathname = usePathname();
 
   if (!open) return;
@@ -38,11 +39,7 @@ export default function LoginModal({ open, onClose, ref }: LoginModalProps) {
   };
 
   return (
-    <div
-      ref={ref}
-      className="absolute left-0 top-0 z-20 flex h-screen w-screen items-center justify-center bg-black/[28%]"
-      onClick={onClose}
-    >
+    <Modal onClose={onClose}>
       <span
         onClick={handleModalClick}
         className="relative flex h-fit w-fit flex-col gap-y-8 rounded-[2rem] bg-white px-8 py-10"
@@ -101,6 +98,6 @@ export default function LoginModal({ open, onClose, ref }: LoginModalProps) {
           </div>
         </div>
       </span>
-    </div>
+    </Modal>
   );
 }

--- a/src/shared/ui/index.ts
+++ b/src/shared/ui/index.ts
@@ -51,6 +51,9 @@ import EmptyState from './emptystate/EmptyState';
 /** Skeletons */
 import { Skeleton } from './skeleton/Skeleton';
 
+/** Modal */
+import Modal from './modal/Modal';
+
 export {
   BadgeButton,
   DropdownChip,
@@ -93,4 +96,5 @@ export {
   CountdownTimer,
   EmptyState,
   Skeleton,
+  Modal,
 };

--- a/src/shared/ui/modal/Modal.tsx
+++ b/src/shared/ui/modal/Modal.tsx
@@ -1,0 +1,56 @@
+'use client';
+
+import { ReactNode, useEffect, useState } from 'react';
+import { createPortal } from 'react-dom';
+
+interface ModalProps {
+  children: ReactNode;
+  onClose: () => void;
+}
+
+export default function Modal({ children, onClose }: ModalProps) {
+  const [modalRoot, setModalRoot] = useState<HTMLElement | null>(null);
+
+  // 모달 루트 노드(#modal-root) 참조 설정
+  useEffect(() => {
+    setModalRoot(document.getElementById('modal-root'));
+  }, []);
+
+  // 모달 열리면 스크롤 잠그고, 닫힐 때 원복
+  useEffect(() => {
+    // 모달이 열릴 때
+    document.body.style.overflow = 'hidden';
+
+    return () => {
+      // 모달이 닫힐 때
+      document.body.style.overflow = '';
+    };
+  }, []);
+
+  // ESC 키로 모달 닫기
+  useEffect(() => {
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') onClose();
+    };
+    window.addEventListener('keydown', onKey);
+    return () => window.removeEventListener('keydown', onKey);
+  }, [onClose]);
+
+  if (!modalRoot) return null; // SSR/초기 렌더 차단
+
+  return createPortal(
+    <div
+      role="dialog"
+      aria-modal="true"
+      className="fixed inset-0 z-20 flex items-center justify-center bg-black/[28%]"
+      onClick={(e) => {
+        if (e.target === e.currentTarget) {
+          onClose();
+        }
+      }}
+    >
+      {children}
+    </div>,
+    modalRoot
+  );
+}


### PR DESCRIPTION
## 변경 사항
- 공통으로 사용할 수 있는 Modal 레이아웃 구현
- LoginModal 컴포넌트에서 ref 제거

## 세부 설명
- Modal 컴포넌트에 createPortal 적용하여 #modal-root로 렌더링
- ESC 키 입력 시 onClose 동작 추가
- 백드롭 클릭 시 닫기 처리, 모달 열릴 때 body 스크롤 잠금

## 관련 이슈
.

## 스크린샷 (선택 사항)
<img width="1728" height="990" alt="image" src="https://github.com/user-attachments/assets/d9bba6d1-13a2-4484-a233-08e6e60d0098" />



## 테스트 방법
변경 사항을 테스트하는 방법에 대한 설명

## 체크리스트
- [x] 코드가 프로젝트의 코딩 스타일을 준수합니다
- [x] 자체 코드 리뷰를 수행했습니다
- [ ] 변경 사항에 대한 테스트가 추가/수정되었습니다
- [ ] 모든 테스트가 통과합니다
- [ ] 필요한 문서를 업데이트했습니다
