### PR TITLE
[FIX] 모든 실시간 인기 게시판에서 금메달 및 1위 문구 표시 되는 부분 수정

### DIFF
--- a/src/views/hotBoards/ui/HotBoard.tsx
+++ b/src/views/hotBoards/ui/HotBoard.tsx
@@ -11,9 +11,9 @@ import {
 import React, { useState } from 'react';
 import { usePathname, useRouter } from 'next/navigation';
 import { useQuery } from '@tanstack/react-query';
-import { axiosHotBoardInfo, axiosPosts } from '@/shared/api';
+import { axiosHotBoardInfo, axiosHotBoardList, axiosPosts } from '@/shared/api';
 import { BoardList } from '@/entities/board';
-import { HotBoardInfoResponse, PostListResponse } from '@/shared/types';
+import { HotBoardInfoResponse, HotBoardResponse, PostListResponse } from '@/shared/types';
 
 interface HotBoardProps {
   /**@param {number} boardId 게시판 Id */
@@ -37,6 +37,12 @@ export default function HotBoard({ boardId }: HotBoardProps) {
     refetchOnMount: true,
   });
 
+  const { data: hotBoardList } = useQuery({
+    queryKey: ['hotBoardList'],
+    queryFn: () => axiosHotBoardList<HotBoardResponse>(),
+    select: (data) => data.boardInfoDtos.findIndex((item) => item.boardId === boardId),
+  });
+
   if (!posts || !boardInfo) return null;
 
   return (
@@ -46,7 +52,11 @@ export default function HotBoard({ boardId }: HotBoardProps) {
           <DateDivider date={new Date()} background="black" />
           <div className="flex items-end justify-between">
             <span className="flex flex-col gap-y-3">
-              <span className="text-base font-semiBold text-brand-500">현재 실시간 검색어 1위</span>
+              {hotBoardList !== undefined && hotBoardList > -1 && (
+                <span className="text-base font-semiBold text-brand-500">
+                  현재 실시간 검색어 {hotBoardList + 1}위
+                </span>
+              )}
               <span className="text-3xl font-bold text-gray-800">{boardInfo.boardName}</span>
             </span>
             <span className="flex flex-col items-end gap-y-2">

--- a/src/views/hotBoards/ui/HotBoard.tsx
+++ b/src/views/hotBoards/ui/HotBoard.tsx
@@ -9,7 +9,6 @@ import {
   SecondaryButton,
 } from '@/shared/ui';
 import React, { useState } from 'react';
-import Image from 'next/image';
 import { usePathname, useRouter } from 'next/navigation';
 import { useQuery } from '@tanstack/react-query';
 import { axiosHotBoardInfo, axiosPosts } from '@/shared/api';
@@ -48,18 +47,7 @@ export default function HotBoard({ boardId }: HotBoardProps) {
           <div className="flex items-end justify-between">
             <span className="flex flex-col gap-y-3">
               <span className="text-base font-semiBold text-brand-500">현재 실시간 검색어 1위</span>
-              <span className="flex gap-x-3">
-                <Image
-                  src="/images/gold.gif"
-                  alt="gold"
-                  width={40}
-                  height={40}
-                  priority
-                  unoptimized
-                  className="aspect-square object-cover"
-                />
-                <span className="text-3xl font-bold text-gray-800">{boardInfo.boardName}</span>
-              </span>
+              <span className="text-3xl font-bold text-gray-800">{boardInfo.boardName}</span>
             </span>
             <span className="flex flex-col items-end gap-y-2">
               <span className="text-sm font-regular text-gray-500">

--- a/src/views/hotBoards/ui/HotBoard.tsx
+++ b/src/views/hotBoards/ui/HotBoard.tsx
@@ -8,7 +8,6 @@ import {
   SecondaryButton,
 } from '@/shared/ui';
 import React, { useState } from 'react';
-import { usePathname, useRouter } from 'next/navigation';
 import { useQuery } from '@tanstack/react-query';
 import { axiosHotBoardInfo, axiosHotBoardList, axiosPosts } from '@/shared/api';
 import { BoardList } from '@/entities/board';


### PR DESCRIPTION
## 변경 사항
모든 실시간 인기 게시판에서 금메달 및 1위 문구 표시 되는 부분 수정

## 세부 설명
현재는 실시간 게시판 리스트 API를 요청해서 순위 비교를 통해 순위를 표시하고 있습니다.
나중에 백엔드에 요청하여 게시판 정보 API의 응답에 담아주는 식으로 바꾸도록 하겠습니다.

## 관련 이슈
#59 

## 스크린샷 (선택 사항)
<img width="878" height="391" alt="image" src="https://github.com/user-attachments/assets/a168ac70-0f17-417a-8108-ef8ceabfd3b6" />

## 테스트 방법
.

## 체크리스트
- [x] 코드가 프로젝트의 코딩 스타일을 준수합니다
- [x] 자체 코드 리뷰를 수행했습니다
- [ ] 변경 사항에 대한 테스트가 추가/수정되었습니다
- [ ] 모든 테스트가 통과합니다
- [ ] 필요한 문서를 업데이트했습니다
