### PR TITLE
실시간 인기 게시판의 날짜별 보기 버튼 삭제

### DIFF
--- a/src/views/hotBoards/ui/HotBoard.tsx
+++ b/src/views/hotBoards/ui/HotBoard.tsx
@@ -1,13 +1,6 @@
 'use client';
 
-import {
-  CountdownTimer,
-  DateDivider,
-  Pagination,
-  Pencil24,
-  PrimaryButton,
-  SecondaryButton,
-} from '@/shared/ui';
+import { CountdownTimer, DateDivider, Pagination, Pencil24, PrimaryButton } from '@/shared/ui';
 import React, { useState } from 'react';
 import Image from 'next/image';
 import { usePathname, useRouter } from 'next/navigation';
@@ -76,18 +69,7 @@ export default function HotBoard({ boardId }: HotBoardProps) {
             </span>
           </div>
         </div>
-        <div className="flex items-center justify-between">
-          <span className="flex items-center gap-x-2">
-            <PrimaryButton variant="primary" size="s">
-              오늘
-            </PrimaryButton>
-            <SecondaryButton variant="primary" size="s">
-              2025년 4월 8일
-            </SecondaryButton>
-            <SecondaryButton variant="primary" size="s">
-              2025년 4월 1일
-            </SecondaryButton>
-          </span>
+        <div className="flex items-center justify-end">
           <PrimaryButton
             variant="black"
             size="m"


### PR DESCRIPTION
## 변경 사항
실시간 인기 게시판의 날짜별 보기 버튼 삭제

## 세부 설명
.

## 관련 이슈
#61 

## 스크린샷 (선택 사항)
<img width="869" height="302" alt="image" src="https://github.com/user-attachments/assets/df82b2c7-e9d7-4d89-ab89-9c86f64762e5" />

## 테스트 방법
.

## 체크리스트
- [x] 코드가 프로젝트의 코딩 스타일을 준수합니다
- [x] 자체 코드 리뷰를 수행했습니다
- [ ] 변경 사항에 대한 테스트가 추가/수정되었습니다
- [ ] 모든 테스트가 통과합니다
- [ ] 필요한 문서를 업데이트했습니다
