### PR TITLE
[FEAT] Link 기반 페이지네이션 구현 및 setPage 함수 방식 지원

### DIFF
--- a/src/features/board/ui/BoardSection.tsx
+++ b/src/features/board/ui/BoardSection.tsx
@@ -6,7 +6,6 @@ import { PostListResponse } from '@/shared/types';
 import { Pagination } from '@/shared/ui';
 import { keepPreviousData, useQuery } from '@tanstack/react-query';
 import { useSearchParams } from 'next/navigation';
-import { useState } from 'react';
 
 interface BoardSectionProps {
   boardId: number;

--- a/src/features/board/ui/BoardSection.tsx
+++ b/src/features/board/ui/BoardSection.tsx
@@ -5,6 +5,7 @@ import { BOARD_PAGE_SIZE } from '@/shared/constants';
 import { PostListResponse } from '@/shared/types';
 import { Pagination } from '@/shared/ui';
 import { keepPreviousData, useQuery } from '@tanstack/react-query';
+import { useSearchParams } from 'next/navigation';
 import { useState } from 'react';
 
 interface BoardSectionProps {
@@ -12,7 +13,8 @@ interface BoardSectionProps {
 }
 
 const BoardSection = ({ boardId }: BoardSectionProps) => {
-  const [page, setPage] = useState(1);
+  const searchParams = useSearchParams();
+  const page = Math.max(1, Number(searchParams.get('page') ?? '1') || 1);
   const { data } = useQuery({
     queryKey: ['posts', boardId, page],
     queryFn: () => axiosPosts<PostListResponse>(boardId, page, BOARD_PAGE_SIZE),
@@ -24,7 +26,12 @@ const BoardSection = ({ boardId }: BoardSectionProps) => {
   return (
     <div className="flex flex-col gap-8">
       <BoardList posts={data.postsListDto} basePath={`/board/${boardId}`} showNumber />
-      <Pagination currentPage={page} maxPage={data.totalPageCount} count={5} setPage={setPage} />
+      <Pagination
+        currentPage={page}
+        maxPage={data.totalPageCount}
+        count={5}
+        getHref={(p) => `/board/${boardId}?page=${p}`}
+      />
     </div>
   );
 };

--- a/src/views/hotBoards/ui/HotBoard.tsx
+++ b/src/views/hotBoards/ui/HotBoard.tsx
@@ -7,7 +7,6 @@ import {
   PrimaryButton,
   SecondaryButton,
 } from '@/shared/ui';
-import React, { useState } from 'react';
 import { useQuery } from '@tanstack/react-query';
 import { axiosHotBoardInfo, axiosHotBoardList, axiosPosts } from '@/shared/api';
 import { BoardList } from '@/entities/board';

--- a/src/views/hotBoards/ui/HotBoard.tsx
+++ b/src/views/hotBoards/ui/HotBoard.tsx
@@ -13,6 +13,7 @@ import { axiosHotBoardInfo, axiosHotBoardList, axiosPosts } from '@/shared/api';
 import { BoardList } from '@/entities/board';
 import { HotBoardInfoResponse, HotBoardResponse, PostListResponse } from '@/shared/types';
 import { BoardWriteButton } from '@/features/board';
+import { useSearchParams } from 'next/navigation';
 
 interface HotBoardProps {
   /**@param {number} boardId 게시판 Id */
@@ -20,7 +21,8 @@ interface HotBoardProps {
 }
 
 export default function HotBoard({ boardId }: HotBoardProps) {
-  const [page, setPage] = useState<number>(1);
+  const searchParams = useSearchParams();
+  const page = Math.max(1, Number(searchParams.get('page') ?? '1') || 1);
 
   const { data: posts } = useQuery({
     queryKey: ['hotBoardPosts', boardId, page],
@@ -89,7 +91,7 @@ export default function HotBoard({ boardId }: HotBoardProps) {
           currentPage={page}
           maxPage={posts.totalPageCount || 1}
           count={5}
-          setPage={setPage}
+          getHref={(p) => `/hotboard/${boardId}?page=${p}`}
         />
       </div>
     </div>


### PR DESCRIPTION
## 변경 사항
- 페이지네이션을 Link 기반 네비게이션으로 구현
- 기존의 setPage 함수를 이용한 페이지 변경 방식도 함께 지원
- URL 쿼리 파라미터(?page=1)를 사용하여 새로고침 시에도 현재 페이지 유지

## 세부 설명
- 페이지네이션 컴포넌트 수정했는데 Link와 setPage 함수 둘다 가능하게 만들려고하니 코드가 좀 더러워졌습니다.

## 관련 이슈
.

## 스크린샷 (선택 사항)



## 테스트 방법
.

## 체크리스트
- [x] 코드가 프로젝트의 코딩 스타일을 준수합니다
- [x] 자체 코드 리뷰를 수행했습니다
- [ ] 변경 사항에 대한 테스트가 추가/수정되었습니다
- [ ] 모든 테스트가 통과합니다
- [ ] 필요한 문서를 업데이트했습니다
