### PR TITLE
[FEAT] Quill 에디터 높이 자동 조절 기능 추가

### DIFF
--- a/src/features/write/ui/RichTextEditor.tsx
+++ b/src/features/write/ui/RichTextEditor.tsx
@@ -124,7 +124,7 @@ const RichTextEditor = forwardRef<RichTextEditorHandle, RichTextEditorProps>(
       }
     }, [initialDelta]);
 
-    return <div ref={editorRef} style={{ minHeight: '300px' }} className="border border-red-500" />;
+    return <div ref={editorRef} style={{ minHeight: '300px' }} />;
   }
 );
 

--- a/src/features/write/ui/RichTextEditor.tsx
+++ b/src/features/write/ui/RichTextEditor.tsx
@@ -90,6 +90,28 @@ const RichTextEditor = forwardRef<RichTextEditorHandle, RichTextEditorProps>(
       // };
     }, [imageHandler]);
 
+    // Quill 에디터의 높이를 내용에 따라 자동으로 조절
+    useEffect(() => {
+      if (!quillRef.current) return;
+
+      const editor = quillRef.current;
+      const editorEl = editor.root;
+
+      const resize = () => {
+        editorEl.style.height = 'auto'; // 👈 먼저 초기화
+        const contentHeight = editorEl.scrollHeight; // 실제 내용 높이
+        const finalHeight = Math.max(contentHeight, 300); // 내용 높이와 300 중에 더 큰 값을 선택
+        editorEl.style.height = `${finalHeight}px`;
+      };
+
+      resize(); // 초기 실행
+      editor.on('text-change', resize); // 글 입력마다 실행
+
+      return () => {
+        editor.off('text-change', resize); // cleanup
+      };
+    }, []);
+
     // 부모 컴포넌트가 getContents 함수를 사용할 수 있도록 연결한다
     useImperativeHandle(ref, () => ({
       getContents: () => quillRef.current?.getContents() ?? new Delta(),
@@ -102,7 +124,7 @@ const RichTextEditor = forwardRef<RichTextEditorHandle, RichTextEditorProps>(
       }
     }, [initialDelta]);
 
-    return <div ref={editorRef} style={{ height: '300px' }} />;
+    return <div ref={editorRef} style={{ minHeight: '300px' }} className="border border-red-500" />;
   }
 );
 


### PR DESCRIPTION
## 변경 사항
- Quill 에디터의 최소 높이를 300px로 설정했습니다.
- 콘텐츠 길이에 따라 에디터의 높이가 자동으로 늘어나도록 구현했습니다.

## 세부 설명
.

## 관련 이슈
.

## 스크린샷 (선택 사항)
<img width="3456" height="3070" alt="image" src="https://github.com/user-attachments/assets/2e23d8f3-a342-49cf-9d94-636f250f6432" />


## 테스트 방법
.

## 체크리스트
- [x] 코드가 프로젝트의 코딩 스타일을 준수합니다
- [x] 자체 코드 리뷰를 수행했습니다
- [ ] 변경 사항에 대한 테스트가 추가/수정되었습니다
- [ ] 모든 테스트가 통과합니다
- [ ] 필요한 문서를 업데이트했습니다
