### PR TITLE
[REFACTOR] BoardSection 컴포넌트 SSR 대응 구조로 리팩토링

### DIFF
--- a/src/app/(main)/(boards)/board/[boardId]/page.tsx
+++ b/src/app/(main)/(boards)/board/[boardId]/page.tsx
@@ -1,6 +1,21 @@
+import { getQueryClient } from '@/providers/queryClient';
+import { axiosPosts } from '@/shared/api';
+import { BOARD_PAGE_SIZE } from '@/shared/constants';
 import { Board } from '@/views/boards';
+import { dehydrate, HydrationBoundary } from '@tanstack/react-query';
 
 export default async function Page({ params }: { params: Promise<{ boardId: string }> }) {
+  const queryClient = getQueryClient();
   const { boardId } = await params;
-  return <Board boardId={Number(boardId)} />;
+
+  await queryClient.prefetchQuery({
+    queryKey: ['posts', Number(boardId), 1],
+    queryFn: () => axiosPosts(Number(boardId), 1, BOARD_PAGE_SIZE),
+  });
+
+  return (
+    <HydrationBoundary state={dehydrate(queryClient)}>
+      <Board boardId={Number(boardId)} />
+    </HydrationBoundary>
+  );
 }

--- a/src/features/board/ui/BoardSection.tsx
+++ b/src/features/board/ui/BoardSection.tsx
@@ -19,12 +19,10 @@ const BoardSection = ({ boardId }: BoardSectionProps) => {
     placeholderData: keepPreviousData,
   });
 
-  if (!data) return null;
-
   return (
     <div className="flex flex-col gap-8">
-      <BoardList posts={data.postsListDto} basePath={`/board/${boardId}`} showNumber />
-      <Pagination currentPage={page} maxPage={data.totalPageCount} count={5} setPage={setPage} />
+      <BoardList posts={data!.postsListDto} basePath={`/board/${boardId}`} showNumber />
+      <Pagination currentPage={page} maxPage={data!.totalPageCount} count={5} setPage={setPage} />
     </div>
   );
 };


### PR DESCRIPTION
## 변경 사항
- BoardSection 컴포넌트 SSR 대응 구조로 리팩토링
- prefetchQuery + dehydrate 방식 적용
- 클라이언트에서 React Query 캐시 활용하여 로딩 없이 게시글 표시

## 세부 설명
.

## 관련 이슈
.

## 스크린샷 (선택 사항)
<img width="3456" height="2412" alt="image" src="https://github.com/user-attachments/assets/c3921a5e-8c22-454b-b057-1d0500d2651f" />


## 테스트 방법
.

## 체크리스트
- [x] 코드가 프로젝트의 코딩 스타일을 준수합니다
- [x] 자체 코드 리뷰를 수행했습니다
- [ ] 변경 사항에 대한 테스트가 추가/수정되었습니다
- [ ] 모든 테스트가 통과합니다
- [ ] 필요한 문서를 업데이트했습니다
