### PR TITLE
[FIX] Quill 에디터 높이 조절 방식을 JS → CSS로 변경

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -15,6 +15,7 @@
 
 .ql-editor {
   padding: 20px !important;
+  overflow-y: hidden !important; /* 세로 스크롤바 제거 */
 }
 
 .ql-editor::before {

--- a/src/features/write/ui/RichTextEditor.tsx
+++ b/src/features/write/ui/RichTextEditor.tsx
@@ -90,28 +90,6 @@ const RichTextEditor = forwardRef<RichTextEditorHandle, RichTextEditorProps>(
       // };
     }, [imageHandler]);
 
-    // Quill 에디터의 높이를 내용에 따라 자동으로 조절
-    useEffect(() => {
-      if (!quillRef.current) return;
-
-      const editor = quillRef.current;
-      const editorEl = editor.root;
-
-      const resize = () => {
-        editorEl.style.height = 'auto'; // 👈 먼저 초기화
-        const contentHeight = editorEl.scrollHeight; // 실제 내용 높이
-        const finalHeight = Math.max(contentHeight, 300); // 내용 높이와 300 중에 더 큰 값을 선택
-        editorEl.style.height = `${finalHeight}px`;
-      };
-
-      resize(); // 초기 실행
-      editor.on('text-change', resize); // 글 입력마다 실행
-
-      return () => {
-        editor.off('text-change', resize); // cleanup
-      };
-    }, []);
-
     // 부모 컴포넌트가 getContents 함수를 사용할 수 있도록 연결한다
     useImperativeHandle(ref, () => ({
       getContents: () => quillRef.current?.getContents() ?? new Delta(),


### PR DESCRIPTION
## 변경 사항
- Quill 에디터 높이 조절 방식을 JS → CSS로 변경

## 세부 설명
.

## 관련 이슈
.

## 스크린샷 (선택 사항)
.

## 테스트 방법
.

## 체크리스트
- [x] 코드가 프로젝트의 코딩 스타일을 준수합니다
- [x] 자체 코드 리뷰를 수행했습니다
- [ ] 변경 사항에 대한 테스트가 추가/수정되었습니다
- [ ] 모든 테스트가 통과합니다
- [ ] 필요한 문서를 업데이트했습니다
