### PR TITLE
[FIX] SSR 하이드레이션 직후 불필요한 재요청 방지를 위해 staleTime 기본값 설정

### DIFF
--- a/src/providers/queryClient.ts
+++ b/src/providers/queryClient.ts
@@ -5,6 +5,7 @@ function makeQueryClient() {
     defaultOptions: {
       queries: {
         refetchOnWindowFocus: false,
+        staleTime: 60 * 1000,
       },
     },
   });


### PR DESCRIPTION
## 변경 사항
- SSR 하이드레이션 직후 불필요한 재요청 방지를 위해 staleTime 기본값 설정

## 세부 설명
- 기본값(staleTime: 0)일 경우, 하이드레이션 후 데이터를 바로 만료로 처리해 재요청이 발생함
- SSR에서 이미 데이터를 가져왔으므로 일정 시간(60초) 동안은 캐시 데이터를 그대로 사용하도록 변경

## 관련 이슈
.

## 스크린샷 (선택 사항)
<img width="3456" height="2650" alt="image" src="https://github.com/user-attachments/assets/d3f09865-2eff-47db-a5d0-1d28e77e4c0c" />


## 테스트 방법
.

## 체크리스트
- [x] 코드가 프로젝트의 코딩 스타일을 준수합니다
- [x] 자체 코드 리뷰를 수행했습니다
- [ ] 변경 사항에 대한 테스트가 추가/수정되었습니다
- [ ] 모든 테스트가 통과합니다
- [ ] 필요한 문서를 업데이트했습니다
