### PR TITLE
[FIX] 메인 페이지 배너 텍스트 수정

### DIFF
--- a/src/views/home/ui/Home.tsx
+++ b/src/views/home/ui/Home.tsx
@@ -24,7 +24,7 @@ export default function Home() {
           🔥 지금 떠오른 이슈들, 사라지기 전에 확인하세요.
         </span>
         <span className="z-10 w-fit select-none font-himpun text-[3.5rem]/[120%] font-regular text-brand-500">
-          04 : 11 : 42
+          Trendnow
         </span>
       </div>
       <div className="flex flex-col gap-y-6">


### PR DESCRIPTION
## 변경 사항
메인 페이지 배너 텍스트 수정

## 세부 설명
기존 타이머로 활용될 예정이었던 배너의 타이머 텍스트를 서비스의 이름으로 임시 수정

## 관련 이슈
#87 

## 스크린샷 (선택 사항)
<img width="820" height="166" alt="image" src="https://github.com/user-attachments/assets/0808ea2d-db17-471e-a252-489f592b3343" />


## 테스트 방법
.

## 체크리스트
- [x] 코드가 프로젝트의 코딩 스타일을 준수합니다
- [x] 자체 코드 리뷰를 수행했습니다
- [ ] 변경 사항에 대한 테스트가 추가/수정되었습니다
- [ ] 모든 테스트가 통과합니다
- [ ] 필요한 문서를 업데이트했습니다
