### PR TITLE
[FEAT] 총 조회수 및 게시글 수 표시 추가

### DIFF
--- a/src/entities/hotBoard/ui/HotBoardList.tsx
+++ b/src/entities/hotBoard/ui/HotBoardList.tsx
@@ -53,8 +53,8 @@ export default function HotBoardList() {
               boardId={item.boardId}
               rank={idx + 1}
               keyword={item.boardName}
-              count={125}
-              views={2324}
+              count={item.postCount}
+              views={item.viewCount}
               timer={item.boardLiveTime}
             />
           ) : (
@@ -63,8 +63,8 @@ export default function HotBoardList() {
               boardId={item.boardId}
               rank={idx + 1}
               keyword={item.boardName}
-              count={125}
-              views={2324}
+              count={item.postCount}
+              views={item.viewCount}
               timer={item.boardLiveTime}
             />
           )

--- a/src/shared/types/hotBoard.ts
+++ b/src/shared/types/hotBoard.ts
@@ -1,12 +1,18 @@
 export interface HotBoardResponse {
+  totalPageCount: number;
+  totalBoardCount: number;
   boardInfoDtos: HotBoardList[];
 }
 
 export interface HotBoardList {
   boardId: number;
   boardName: string;
+  postCount: number;
+  viewCount: number;
   boardLiveTime: number;
   score: number;
+  createdAt: string;
+  updatedAt: string;
 }
 
 export interface HotBoardInfoResponse {


### PR DESCRIPTION
## 변경 사항
총 조회수 및 게시글 수 표시 추가

## 세부 설명
현재 임시적인 데이터를 보여주고 있는 총 조회수 및 게시글 수 부분을 실제 데이터를 반영하도록 수정했습니다.

## 관련 이슈
#89 

## 스크린샷 (선택 사항)
<img width="840" height="310" alt="image" src="https://github.com/user-attachments/assets/d4c363ac-6783-4424-93a7-a275cad4b77a" />


## 테스트 방법
.

## 체크리스트
- [x] 코드가 프로젝트의 코딩 스타일을 준수합니다
- [x] 자체 코드 리뷰를 수행했습니다
- [ ] 변경 사항에 대한 테스트가 추가/수정되었습니다
- [ ] 모든 테스트가 통과합니다
- [ ] 필요한 문서를 업데이트했습니다
