### PR TITLE
[FIX] 마이페이지 스크랩한 게시글 이동 불가능 수정

### DIFF
--- a/src/shared/constants/board.ts
+++ b/src/shared/constants/board.ts
@@ -7,9 +7,3 @@ export const BOARD_MAP = {
   politics: { id: 12, name: '정치' },
   entertain: { id: 13, name: '연예' },
 } as const;
-
-export enum BOARD_IDS {
-  FREE = BOARD_MAP.free.id,
-  POLITICS = BOARD_MAP.politics.id,
-  ENTERTAIN = BOARD_MAP.entertain.id,
-}

--- a/src/shared/constants/board.ts
+++ b/src/shared/constants/board.ts
@@ -4,8 +4,12 @@ export const BOARD_PAGE_SIZE = 5;
 // 게시판 타입별 ID, 이름, path 매핑
 export const BOARD_MAP = {
   free: { id: 11, name: '자유' },
-  entertain: { id: 13, name: '연예' },
   politics: { id: 12, name: '정치' },
+  entertain: { id: 13, name: '연예' },
 } as const;
 
-export const BOARD_IDS = [1814, 1815, 1816];
+export enum BOARD_IDS {
+  FREE = BOARD_MAP.free.id,
+  POLITICS = BOARD_MAP.politics.id,
+  ENTERTAIN = BOARD_MAP.entertain.id,
+}

--- a/src/shared/constants/index.ts
+++ b/src/shared/constants/index.ts
@@ -1,3 +1,3 @@
-import { BOARD_PAGE_SIZE, BOARD_MAP, BOARD_IDS } from './board';
+import { BOARD_PAGE_SIZE, BOARD_MAP } from './board';
 
-export { BOARD_PAGE_SIZE, BOARD_MAP, BOARD_IDS };
+export { BOARD_PAGE_SIZE, BOARD_MAP };

--- a/src/widgets/mypage/ui/MyCommentRow.tsx
+++ b/src/widgets/mypage/ui/MyCommentRow.tsx
@@ -1,4 +1,4 @@
-import { BOARD_IDS } from '@/shared/constants';
+import { BOARD_MAP } from '@/shared/constants';
 import dayjs from 'dayjs';
 import Link from 'next/link';
 import React from 'react';
@@ -17,7 +17,9 @@ interface MyCommentRowProps {
 }
 
 const MyCommentRow = ({ boardId, postId, title, created, comment }: MyCommentRowProps) => {
-  const boardPath = [BOARD_IDS.FREE, BOARD_IDS.POLITICS, BOARD_IDS.ENTERTAIN].includes(boardId)
+  const boardPath = [BOARD_MAP.free, BOARD_MAP.politics, BOARD_MAP.entertain].find(
+    (board) => board.id === boardId
+  )
     ? `/board/${boardId}/post/${postId}`
     : `/hotboard/${boardId}/post/${postId}`;
 

--- a/src/widgets/mypage/ui/MyCommentRow.tsx
+++ b/src/widgets/mypage/ui/MyCommentRow.tsx
@@ -17,7 +17,7 @@ interface MyCommentRowProps {
 }
 
 const MyCommentRow = ({ boardId, postId, title, created, comment }: MyCommentRowProps) => {
-  const boardPath = new Set([BOARD_IDS.FREE, BOARD_IDS.POLITICS, BOARD_IDS.ENTERTAIN]).has(boardId)
+  const boardPath = [BOARD_IDS.FREE, BOARD_IDS.POLITICS, BOARD_IDS.ENTERTAIN].includes(boardId)
     ? `/board/${boardId}/post/${postId}`
     : `/hotboard/${boardId}/post/${postId}`;
 

--- a/src/widgets/mypage/ui/MyCommentRow.tsx
+++ b/src/widgets/mypage/ui/MyCommentRow.tsx
@@ -17,7 +17,7 @@ interface MyCommentRowProps {
 }
 
 const MyCommentRow = ({ boardId, postId, title, created, comment }: MyCommentRowProps) => {
-  const boardPath = BOARD_IDS.includes(boardId)
+  const boardPath = new Set([BOARD_IDS.FREE, BOARD_IDS.POLITICS, BOARD_IDS.ENTERTAIN]).has(boardId)
     ? `/board/${boardId}/post/${postId}`
     : `/hotboard/${boardId}/post/${postId}`;
 

--- a/src/widgets/mypage/ui/MyPostRow.tsx
+++ b/src/widgets/mypage/ui/MyPostRow.tsx
@@ -21,7 +21,7 @@ interface MyPostRowProps {
 }
 
 const MyPostRow = ({ boardId, postId, title, views, likes, created, comments }: MyPostRowProps) => {
-  const boardPath = new Set([BOARD_IDS.FREE, BOARD_IDS.POLITICS, BOARD_IDS.ENTERTAIN]).has(boardId)
+  const boardPath = [BOARD_IDS.FREE, BOARD_IDS.POLITICS, BOARD_IDS.ENTERTAIN].includes(boardId)
     ? `/board/${boardId}/post/${postId}`
     : `/hotboard/${boardId}/post/${postId}`;
 

--- a/src/widgets/mypage/ui/MyPostRow.tsx
+++ b/src/widgets/mypage/ui/MyPostRow.tsx
@@ -21,7 +21,7 @@ interface MyPostRowProps {
 }
 
 const MyPostRow = ({ boardId, postId, title, views, likes, created, comments }: MyPostRowProps) => {
-  const boardPath = BOARD_IDS.includes(boardId)
+  const boardPath = new Set([BOARD_IDS.FREE, BOARD_IDS.POLITICS, BOARD_IDS.ENTERTAIN]).has(boardId)
     ? `/board/${boardId}/post/${postId}`
     : `/hotboard/${boardId}/post/${postId}`;
 

--- a/src/widgets/mypage/ui/MyPostRow.tsx
+++ b/src/widgets/mypage/ui/MyPostRow.tsx
@@ -1,4 +1,4 @@
-import { BOARD_IDS } from '@/shared/constants';
+import { BOARD_MAP } from '@/shared/constants';
 import dayjs from 'dayjs';
 import Link from 'next/link';
 import React from 'react';
@@ -21,7 +21,9 @@ interface MyPostRowProps {
 }
 
 const MyPostRow = ({ boardId, postId, title, views, likes, created, comments }: MyPostRowProps) => {
-  const boardPath = [BOARD_IDS.FREE, BOARD_IDS.POLITICS, BOARD_IDS.ENTERTAIN].includes(boardId)
+  const boardPath = [BOARD_MAP.free, BOARD_MAP.politics, BOARD_MAP.entertain].find(
+    (board) => board.id === boardId
+  )
     ? `/board/${boardId}/post/${postId}`
     : `/hotboard/${boardId}/post/${postId}`;
 

--- a/src/widgets/mypage/ui/MyScrapRow.tsx
+++ b/src/widgets/mypage/ui/MyScrapRow.tsx
@@ -37,7 +37,7 @@ const MyScrapRow = ({
   created,
   comments,
 }: MyScrapRowProps) => {
-  const boardPath = new Set([BOARD_IDS.FREE, BOARD_IDS.POLITICS, BOARD_IDS.ENTERTAIN]).has(boardId)
+  const boardPath = [BOARD_IDS.FREE, BOARD_IDS.POLITICS, BOARD_IDS.ENTERTAIN].includes(boardId)
     ? `/board/${boardId}/post/${postId}`
     : `/hotboard/${boardId}/post/${postId}`;
 

--- a/src/widgets/mypage/ui/MyScrapRow.tsx
+++ b/src/widgets/mypage/ui/MyScrapRow.tsx
@@ -1,4 +1,5 @@
 import { ScrapToggleButton } from '@/features/scrap';
+import { BOARD_IDS } from '@/shared/constants';
 import { UserProfile20 } from '@/shared/ui';
 import dayjs from 'dayjs';
 import Link from 'next/link';
@@ -36,8 +37,12 @@ const MyScrapRow = ({
   created,
   comments,
 }: MyScrapRowProps) => {
+  const boardPath = new Set([BOARD_IDS.FREE, BOARD_IDS.POLITICS, BOARD_IDS.ENTERTAIN]).has(boardId)
+    ? `/board/${boardId}/post/${postId}`
+    : `/hotboard/${boardId}/post/${postId}`;
+
   return (
-    <Link href={`/board/${boardId}/post/${postId}`}>
+    <Link href={boardPath}>
       <div className="flex w-full justify-between border-b border-gray-200 px-2 py-4">
         <div className="flex items-center gap-4">
           <ScrapToggleButton size={'s'} />

--- a/src/widgets/mypage/ui/MyScrapRow.tsx
+++ b/src/widgets/mypage/ui/MyScrapRow.tsx
@@ -1,5 +1,5 @@
 import { ScrapToggleButton } from '@/features/scrap';
-import { BOARD_IDS } from '@/shared/constants';
+import { BOARD_MAP } from '@/shared/constants';
 import { UserProfile20 } from '@/shared/ui';
 import dayjs from 'dayjs';
 import Link from 'next/link';
@@ -37,7 +37,9 @@ const MyScrapRow = ({
   created,
   comments,
 }: MyScrapRowProps) => {
-  const boardPath = [BOARD_IDS.FREE, BOARD_IDS.POLITICS, BOARD_IDS.ENTERTAIN].includes(boardId)
+  const boardPath = [BOARD_MAP.free, BOARD_MAP.politics, BOARD_MAP.entertain].find(
+    (board) => board.id === boardId
+  )
     ? `/board/${boardId}/post/${postId}`
     : `/hotboard/${boardId}/post/${postId}`;
 


### PR DESCRIPTION
## 변경 사항
실시간 인기 게시판의 게시글을 북마크 했을 때, 마이페이지에서 해당 게시글을 클릭하여 이동하는 것이 불가능 했던 문제 수정

## 세부 설명
'스크랩한 게시글' 탭 외에도 '내가 작성한 게시글' 및 '내가 작성한 댓글' 탭도 비슷한 문제가 있었기 때문에 수정했습니다.

## 관련 이슈
#109 

## 스크린샷 (선택 사항)
.

## 테스트 방법
.

## 체크리스트
- [x] 코드가 프로젝트의 코딩 스타일을 준수합니다
- [x] 자체 코드 리뷰를 수행했습니다
- [ ] 변경 사항에 대한 테스트가 추가/수정되었습니다
- [ ] 모든 테스트가 통과합니다
- [ ] 필요한 문서를 업데이트했습니다
