### PR TITLE
[BUG] 검색 결과에서 pagination 작동 오류 수정

### DIFF
--- a/src/entities/search/ui/SearchTypeTabs.tsx
+++ b/src/entities/search/ui/SearchTypeTabs.tsx
@@ -11,9 +11,10 @@ interface SearchTypeTabsProps {
   tabs: Tab[];
   currentTab: BoardType;
   onTabChange: (key: BoardType) => void;
+  setPage: (page: number) => void;
 }
 
-const SearchTypeTabs = ({ tabs, currentTab, onTabChange }: SearchTypeTabsProps) => {
+const SearchTypeTabs = ({ tabs, currentTab, onTabChange, setPage }: SearchTypeTabsProps) => {
   return (
     <div className="flex gap-x-2">
       {tabs.map((tab) => {
@@ -33,7 +34,10 @@ const SearchTypeTabs = ({ tabs, currentTab, onTabChange }: SearchTypeTabsProps) 
             variant="gray"
             size="s"
             className="text-nowrap rounded-full"
-            onClick={() => onTabChange(tab.key)}
+            onClick={() => {
+              onTabChange(tab.key);
+              setPage(1);
+            }}
           >
             {tab.label} {tab.count}건
           </SecondaryButton>

--- a/src/widgets/search/ui/FixedBoardsSection.tsx
+++ b/src/widgets/search/ui/FixedBoardsSection.tsx
@@ -21,23 +21,22 @@ interface Tab {
 const FixedBoardsSection = ({ keyword }: FixedBoardsSectionProps) => {
   const [page, setPage] = useState(1);
   const [currentTab, setCurrentTab] = useState<BoardType>('free');
-
   const { data: freePosts } = useQuery({
-    queryKey: ['searchFixedBoardPosts', keyword, BOARD_MAP.free.id, 1],
+    queryKey: ['searchFixedBoardPosts', keyword, BOARD_MAP.free.id, page],
     queryFn: () =>
-      axiosSearchFixedBoardPosts<SearchFixedBoardsResponse>(keyword, BOARD_MAP.free.id),
+      axiosSearchFixedBoardPosts<SearchFixedBoardsResponse>(keyword, BOARD_MAP.free.id, page),
     select: (data) => data.searchResult,
   });
   const { data: entertainPosts } = useQuery({
-    queryKey: ['searchFixedBoardPosts', keyword, BOARD_MAP.entertain.id, 1],
+    queryKey: ['searchFixedBoardPosts', keyword, BOARD_MAP.entertain.id, page],
     queryFn: () =>
-      axiosSearchFixedBoardPosts<SearchFixedBoardsResponse>(keyword, BOARD_MAP.entertain.id),
+      axiosSearchFixedBoardPosts<SearchFixedBoardsResponse>(keyword, BOARD_MAP.entertain.id, page),
     select: (data) => data.searchResult,
   });
   const { data: politicsPosts } = useQuery({
-    queryKey: ['searchFixedBoardPosts', keyword, BOARD_MAP.politics.id, 1],
+    queryKey: ['searchFixedBoardPosts', keyword, BOARD_MAP.politics.id, page],
     queryFn: () =>
-      axiosSearchFixedBoardPosts<SearchFixedBoardsResponse>(keyword, BOARD_MAP.politics.id),
+      axiosSearchFixedBoardPosts<SearchFixedBoardsResponse>(keyword, BOARD_MAP.politics.id, page),
     select: (data) => data.searchResult,
   });
 
@@ -67,7 +66,12 @@ const FixedBoardsSection = ({ keyword }: FixedBoardsSectionProps) => {
   return (
     <section aria-label="고정 게시판 게시글 목록" className="flex flex-col gap-5">
       <SearchSectionTitle title="고정 게시판" count={totalCount} />
-      <SearchTypeTabs tabs={tabs} currentTab={currentTab} onTabChange={setCurrentTab} />
+      <SearchTypeTabs
+        tabs={tabs}
+        currentTab={currentTab}
+        onTabChange={setCurrentTab}
+        setPage={setPage}
+      />
       {postData.postList.length === 0 ? (
         <EmptyState
           message={`검색하신 키워드에 대한 게시글이 아직 없습니다. \n 지금 첫 번째 글을 작성해보세요.`}


### PR DESCRIPTION
## 변경 사항
- 검색 결과에서 1페이지만 작동하는 오류 해결
- 다른 탭으로 이동시 페이지 1로 다시 변경

## 세부 설명
.

## 관련 이슈
#118 

## 스크린샷 (선택 사항)
<img width="3456" height="4648" alt="image" src="https://github.com/user-attachments/assets/fd608188-ded3-42cf-979b-9aef66518c68" />


## 테스트 방법
.

## 체크리스트
- [x] 코드가 프로젝트의 코딩 스타일을 준수합니다
- [x] 자체 코드 리뷰를 수행했습니다
- [ ] 변경 사항에 대한 테스트가 추가/수정되었습니다
- [ ] 모든 테스트가 통과합니다
- [ ] 필요한 문서를 업데이트했습니다
