### PR TITLE
[FEAT] hotboard 목록 페이지네이션

### DIFF
--- a/src/app/(main)/(boards)/page.tsx
+++ b/src/app/(main)/(boards)/page.tsx
@@ -1,5 +1,10 @@
 import { Home } from '@/views/home';
+import { Suspense } from 'react';
 
 export default function Page() {
-  return <Home />;
+  return (
+    <Suspense>
+      <Home />
+    </Suspense>
+  );
 }

--- a/src/entities/hotBoard/ui/HotBoardList.tsx
+++ b/src/entities/hotBoard/ui/HotBoardList.tsx
@@ -1,18 +1,25 @@
+'use client';
+
 import React, { useEffect } from 'react';
 import HotBoardListRow from './HotBoardListRow';
 import MedalRow from './MedalRow';
 import { useQuery, useQueryClient } from '@tanstack/react-query';
 import { axiosDisconnectSSE, axiosHotBoardList, SSE } from '@/shared/api';
 import { BoardTimeUp, HotBoardResponse } from '@/shared/types';
+import { Pagination } from '@/shared/ui';
+import { useSearchParams } from 'next/navigation';
 
 export default function HotBoardList() {
+  const searchParams = useSearchParams();
   const queryClient = useQueryClient();
 
-  const queryKey = ['hotBoardList'];
+  const page = Math.max(1, Number(searchParams.get('page') ?? '1') || 1);
+
+  const queryKey = ['hotBoardList', page];
 
   const { data } = useQuery({
     queryKey: queryKey,
-    queryFn: () => axiosHotBoardList<HotBoardResponse>(),
+    queryFn: () => axiosHotBoardList<HotBoardResponse>(page),
     refetchOnMount: true,
   });
 
@@ -37,38 +44,48 @@ export default function HotBoardList() {
   if (!data) return null;
 
   return (
-    <div className="flex flex-col gap-y-2">
-      <div className="flex gap-x-3 border-b border-gray-200 px-2 pb-4 *:text-nowrap *:text-sm *:font-regular *:text-gray-500">
-        <span className="w-12 text-center">순위</span>
-        <span className="flex-1 text-left">검색어</span>
-        <span className="w-16 text-center">게시물 수</span>
-        <span className="w-16 text-center">총 조회수</span>
-        <span className="w-[6.5rem] text-center">타이머</span>
+    <div className="flex flex-col gap-y-8">
+      <div className="flex flex-col gap-y-2">
+        <div className="flex gap-x-3 border-b border-gray-200 px-2 pb-4 *:text-nowrap *:text-sm *:font-regular *:text-gray-500">
+          <span className="w-12 text-center">순위</span>
+          <span className="flex-1 text-left">검색어</span>
+          <span className="w-16 text-center">게시물 수</span>
+          <span className="w-16 text-center">총 조회수</span>
+          <span className="w-[6.5rem] text-center">타이머</span>
+        </div>
+        {data &&
+          data.boardInfoDtos.map((item, idx) =>
+            page === 1 && idx < 3 ? (
+              <MedalRow
+                key={item.boardId}
+                boardId={item.boardId}
+                rank={idx + 1 + (page - 1) * 10}
+                keyword={item.boardName}
+                count={item.postCount}
+                views={item.viewCount}
+                timer={item.boardLiveTime}
+              />
+            ) : (
+              <HotBoardListRow
+                key={item.boardId}
+                boardId={item.boardId}
+                rank={idx + 1 + (page - 1) * 10}
+                keyword={item.boardName}
+                count={item.postCount}
+                views={item.viewCount}
+                timer={item.boardLiveTime}
+              />
+            )
+          )}
       </div>
-      {data &&
-        data.boardInfoDtos.map((item, idx) =>
-          idx < 3 ? (
-            <MedalRow
-              key={item.boardId}
-              boardId={item.boardId}
-              rank={idx + 1}
-              keyword={item.boardName}
-              count={item.postCount}
-              views={item.viewCount}
-              timer={item.boardLiveTime}
-            />
-          ) : (
-            <HotBoardListRow
-              key={item.boardId}
-              boardId={item.boardId}
-              rank={idx + 1}
-              keyword={item.boardName}
-              count={item.postCount}
-              views={item.viewCount}
-              timer={item.boardLiveTime}
-            />
-          )
-        )}
+      {data.boardInfoDtos.length > 0 && (
+        <Pagination
+          currentPage={page}
+          maxPage={data!.totalPageCount}
+          count={5}
+          getHref={(p) => `/?page=${p}`}
+        />
+      )}
     </div>
   );
 }

--- a/src/views/home/ui/Home.tsx
+++ b/src/views/home/ui/Home.tsx
@@ -1,5 +1,3 @@
-'use client';
-
 import { HotBoardList } from '@/entities/hotBoard';
 import { DateDivider } from '@/shared/ui';
 import { SortChip, SortChipItem } from '@/widgets/hotBoards';


### PR DESCRIPTION
## 변경 사항
메인 화면 실시간 인기 게시판 목록 페이지네이션 추가

## 세부 설명
현재 페이지를 기억할 수 있도록 구현했습니다.

## 관련 이슈
#128 

## 스크린샷 (선택 사항)
<img width="878" height="843" alt="image" src="https://github.com/user-attachments/assets/e3125dab-4a4f-4322-965a-e7e8bdf1604e" />
<img width="885" height="812" alt="image" src="https://github.com/user-attachments/assets/db58c96c-5b78-4af5-a4dd-9bec2ff4416b" />
<img width="878" height="302" alt="image" src="https://github.com/user-attachments/assets/644cafe5-70d8-489a-bec3-993a6ff20fac" />


## 테스트 방법
.

## 체크리스트
- [x] 코드가 프로젝트의 코딩 스타일을 준수합니다
- [x] 자체 코드 리뷰를 수행했습니다
- [ ] 변경 사항에 대한 테스트가 추가/수정되었습니다
- [ ] 모든 테스트가 통과합니다
- [ ] 필요한 문서를 업데이트했습니다
