### PR TITLE
[FIX] 사이드바 키워드 표시 오류 수정

### DIFF
--- a/src/entities/hotBoard/ui/HotBoardList.tsx
+++ b/src/entities/hotBoard/ui/HotBoardList.tsx
@@ -5,7 +5,7 @@ import HotBoardListRow from './HotBoardListRow';
 import MedalRow from './MedalRow';
 import { useQuery, useQueryClient } from '@tanstack/react-query';
 import { axiosHotBoardList, SSE } from '@/shared/api';
-import { BoardTimeUp, HotBoardResponse } from '@/shared/types';
+import { HotBoardResponse } from '@/shared/types';
 import { Pagination } from '@/shared/ui';
 import { useSearchParams } from 'next/navigation';
 
@@ -28,9 +28,7 @@ export default function HotBoardList() {
 
     const { eventSource } = sseInstance.getEventSource();
 
-    eventSource.addEventListener('realtimeBoardTimeUp', (e) => {
-      const data: BoardTimeUp = JSON.parse(e.data);
-      console.log('HotBoardList', data);
+    eventSource.addEventListener('realtimeBoardTimeUp', () => {
       queryClient.invalidateQueries({ queryKey: queryKey });
     });
   }, []);

--- a/src/entities/hotBoard/ui/HotBoardList.tsx
+++ b/src/entities/hotBoard/ui/HotBoardList.tsx
@@ -4,7 +4,7 @@ import React, { useEffect } from 'react';
 import HotBoardListRow from './HotBoardListRow';
 import MedalRow from './MedalRow';
 import { useQuery, useQueryClient } from '@tanstack/react-query';
-import { axiosDisconnectSSE, axiosHotBoardList, SSE } from '@/shared/api';
+import { axiosHotBoardList, SSE } from '@/shared/api';
 import { BoardTimeUp, HotBoardResponse } from '@/shared/types';
 import { Pagination } from '@/shared/ui';
 import { useSearchParams } from 'next/navigation';
@@ -26,19 +26,13 @@ export default function HotBoardList() {
   useEffect(() => {
     const sseInstance = SSE.getInstance();
 
-    const { eventSource, clientId } = sseInstance.getEventSource();
+    const { eventSource } = sseInstance.getEventSource();
 
     eventSource.addEventListener('realtimeBoardTimeUp', (e) => {
       const data: BoardTimeUp = JSON.parse(e.data);
       console.log('HotBoardList', data);
       queryClient.invalidateQueries({ queryKey: queryKey });
     });
-
-    return () => {
-      console.log('SSE connection closed');
-      eventSource?.close();
-      (async () => await axiosDisconnectSSE(clientId))();
-    };
   }, []);
 
   if (!data) return null;

--- a/src/shared/types/index.ts
+++ b/src/shared/types/index.ts
@@ -6,6 +6,5 @@ export * from './comment';
 export * from './write';
 export * from './hotBoard';
 export * from './sse';
-export * from './realtime';
 export * from './user';
 export * from './mypage';

--- a/src/shared/types/realtime.ts
+++ b/src/shared/types/realtime.ts
@@ -1,6 +1,0 @@
-import { Top10 } from './sse';
-
-export interface RealtimeTop10Response {
-  now: string;
-  top10: Top10[];
-}

--- a/src/shared/types/sse/sseTypes.ts
+++ b/src/shared/types/sse/sseTypes.ts
@@ -6,7 +6,7 @@ export interface Top10 {
   rank: number;
   keyword: string;
   rankChangeType: RankChangeType;
-  diffRank?: number;
+  diffRank: number;
 }
 
 export interface SignalKeyword {

--- a/src/shared/types/sse/sseTypes.ts
+++ b/src/shared/types/sse/sseTypes.ts
@@ -2,10 +2,11 @@ import { RankChangeType } from './sseEnums';
 import { ErrorEvent } from 'eventsource';
 
 export interface Top10 {
+  boardId: number;
   rank: number;
   keyword: string;
   rankChangeType: RankChangeType;
-  previousRank?: number;
+  diffRank?: number;
 }
 
 export interface SignalKeyword {

--- a/src/widgets/sideBar/ui/TrendBar.tsx
+++ b/src/widgets/sideBar/ui/TrendBar.tsx
@@ -1,12 +1,11 @@
 'use client';
 
 import Image from 'next/image';
-import React, { memo, useEffect, useState } from 'react';
-import { Bar, Down, Up } from './icons';
+import React, { useEffect, useState } from 'react';
 import { axiosRealtimeTop10, SSE } from '@/shared/api';
-import { Top10, RankChangeType, SignalKeyword } from '@/shared/types';
+import { SignalKeyword } from '@/shared/types';
 import dayjs from 'dayjs';
-import Link from 'next/link';
+import TrendBarRow from './TrendBarRow';
 
 export default function TrendBar() {
   const [top10, setTop10] = useState<SignalKeyword>();
@@ -54,7 +53,7 @@ export default function TrendBar() {
         <div className="flex flex-col gap-y-1 rounded-[1.25rem] bg-white/[8%] p-3">
           {top10 &&
             top10.top10WithDiff?.map((item) => (
-              <Top10Row
+              <TrendBarRow
                 key={item.keyword}
                 boardId={item.boardId}
                 rank={item.rank}
@@ -68,39 +67,3 @@ export default function TrendBar() {
     </div>
   );
 }
-
-const Top10Row = memo(function Row({ boardId, rank, keyword, rankChangeType, diffRank }: Top10) {
-  return (
-    <Link href={`/hotboard/${boardId}`}>
-      <div className="flex cursor-pointer justify-between rounded-xl py-2 pr-3 hover:bg-white/[16%] hover:pl-3">
-        <div className="flex min-w-0 items-center gap-x-3">
-          <span className="h-7 w-7 text-center text-xl font-semiBold text-white">{rank}</span>
-          <span className="flex-1 truncate text-lg font-semiBold text-white">{keyword}</span>
-        </div>
-        {diffRank ? (
-          rankChangeType === RankChangeType.UP ? (
-            <div className="flex items-center gap-x-0.5">
-              <Up />
-              <span className="text-base font-medium text-white">{diffRank}</span>
-            </div>
-          ) : rankChangeType === RankChangeType.DOWN ? (
-            <div className="flex items-center gap-x-0.5">
-              <Down />
-              <span className="text-base font-medium text-[#1056AC]">{diffRank}</span>
-            </div>
-          ) : (
-            <div className="flex items-center gap-x-0.5">
-              <Bar />
-            </div>
-          )
-        ) : (
-          <div className="flex items-center gap-x-0.5">
-            <span className="text-base font-medium text-white">NEW</span>
-          </div>
-        )}
-      </div>
-    </Link>
-  );
-});
-
-Top10Row.displayName = 'Top10Row';

--- a/src/widgets/sideBar/ui/TrendBar.tsx
+++ b/src/widgets/sideBar/ui/TrendBar.tsx
@@ -27,10 +27,10 @@ export default function TrendBar() {
   }, []);
 
   return (
-    <div className="sticky top-[104px] flex h-fit w-full flex-col gap-y-5 rounded-3xl bg-brand-500 p-5">
-      <div className="flex flex-col gap-y-6">
-        <span className="flex w-fit flex-col gap-y-1.5">
-          <span className="text-lg font-semiBold text-brand-100">
+    <div className="sticky top-[104px] flex h-fit w-full flex-col rounded-3xl bg-brand-500">
+      <div className="flex flex-col gap-y-6 p-5">
+        <span className="flex w-fit flex-col gap-y-2">
+          <span className="text-base font-semiBold text-brand-100">
             가장 뜨거운 실시간 인기 검색어
           </span>
           <span className="flex w-fit items-center gap-x-1.5">
@@ -47,21 +47,25 @@ export default function TrendBar() {
         </span>
       </div>
       <div className="flex flex-col gap-y-3">
-        <div className="flex h-10 items-center rounded-xl bg-black/[0.16] px-3 py-2 text-md font-medium text-white">
-          {dayjs(today).format('YYYY.MM.DD HH:mm 기준')}
+        <div className="px-5">
+          <span className="flex h-10 items-center rounded-xl bg-black/[0.16] px-3 py-2 text-md font-medium text-white">
+            {dayjs(today).format('YYYY.MM.DD HH:mm 기준')}
+          </span>
         </div>
-        <div className="flex flex-col gap-y-1 rounded-[1.25rem] bg-white/[8%] p-3">
-          {top10 &&
-            top10.top10WithDiff?.map((item) => (
-              <TrendBarRow
-                key={item.keyword}
-                boardId={item.boardId}
-                rank={item.rank}
-                keyword={item.keyword}
-                rankChangeType={item.rankChangeType}
-                diffRank={item.diffRank}
-              />
-            ))}
+        <div className="px-5 pb-5">
+          <div className="flex flex-col gap-y-1 rounded-[1.25rem] bg-white/[8%] p-2">
+            {top10 &&
+              top10.top10WithDiff?.map((item) => (
+                <TrendBarRow
+                  key={item.keyword}
+                  boardId={item.boardId}
+                  rank={item.rank}
+                  keyword={item.keyword}
+                  rankChangeType={item.rankChangeType}
+                  diffRank={item.diffRank}
+                />
+              ))}
+          </div>
         </div>
       </div>
     </div>

--- a/src/widgets/sideBar/ui/TrendBarRow.tsx
+++ b/src/widgets/sideBar/ui/TrendBarRow.tsx
@@ -1,0 +1,19 @@
+import { Top10 } from '@/shared/types';
+import Link from 'next/link';
+import TrendBarRowType from './TrendBarRowType';
+
+export default function TrendBarRow({ boardId, rank, keyword, rankChangeType, diffRank }: Top10) {
+  return (
+    <Link href={`/hotboard/${boardId}`}>
+      <div className="flex cursor-pointer justify-between rounded-xl py-2 pr-3 hover:bg-white/[16%] hover:pl-3">
+        <div className="flex min-w-0 items-center gap-x-3">
+          <span className="h-7 w-7 text-center text-xl font-semiBold text-white">{rank}</span>
+          <span className="flex-1 truncate text-lg font-semiBold text-white">{keyword}</span>
+        </div>
+        <div className="flex items-center gap-x-0.5">
+          <TrendBarRowType rankChangeType={rankChangeType} diffRank={diffRank} />
+        </div>
+      </div>
+    </Link>
+  );
+}

--- a/src/widgets/sideBar/ui/TrendBarRow.tsx
+++ b/src/widgets/sideBar/ui/TrendBarRow.tsx
@@ -5,13 +5,15 @@ import TrendBarRowType from './TrendBarRowType';
 export default function TrendBarRow({ boardId, rank, keyword, rankChangeType, diffRank }: Top10) {
   return (
     <Link href={`/hotboard/${boardId}`}>
-      <div className="flex cursor-pointer justify-between rounded-xl py-2 pr-3 hover:bg-white/[16%] hover:pl-3">
-        <div className="flex min-w-0 items-center gap-x-3">
-          <span className="h-7 w-7 text-center text-xl font-semiBold text-white">{rank}</span>
-          <span className="flex-1 truncate text-lg font-semiBold text-white">{keyword}</span>
-        </div>
-        <div className="flex items-center gap-x-0.5">
-          <TrendBarRowType rankChangeType={rankChangeType} diffRank={diffRank} />
+      <div className="cursor-pointer rounded-xl px-1.5 py-0.5 transition duration-300 hover:bg-white/[8%]">
+        <div className="flex items-center gap-x-1 py-2 pr-3">
+          <div className="flex min-w-0 items-center gap-x-3">
+            <span className="h-7 w-7 text-center text-xl font-semiBold text-white">{rank}</span>
+            <span className="flex-1 truncate text-lg font-semiBold text-white">{keyword}</span>
+          </div>
+          <div className="flex items-center gap-x-0.5">
+            <TrendBarRowType rankChangeType={rankChangeType} diffRank={diffRank} />
+          </div>
         </div>
       </div>
     </Link>

--- a/src/widgets/sideBar/ui/TrendBarRowType.tsx
+++ b/src/widgets/sideBar/ui/TrendBarRowType.tsx
@@ -1,0 +1,40 @@
+import { RankChangeType } from '@/shared/types';
+import { Up, Down, Bar } from './icons';
+
+interface TrendBarRowTypeProps {
+  /**@param {RankChangeType} rankChangeType 키워드의 순위 변동 유형 */
+  rankChangeType: RankChangeType;
+  /**@param {number} diffRank 키워드의 순위 변동 크기 */
+  diffRank: number;
+}
+
+export default function TrendBarRowType({ rankChangeType, diffRank }: TrendBarRowTypeProps) {
+  switch (rankChangeType) {
+    case RankChangeType.UP:
+      return (
+        <>
+          <Up />
+          <span className="text-base font-medium text-white">{diffRank}</span>
+        </>
+      );
+    case RankChangeType.DOWN:
+      return (
+        <>
+          <Down />
+          <span className="text-base font-medium text-[#1056AC]">{diffRank}</span>
+        </>
+      );
+    case RankChangeType.SAME:
+      return (
+        <>
+          <Bar />
+        </>
+      );
+    case RankChangeType.NEW:
+      return (
+        <>
+          <span className="text-base font-medium text-white">NEW</span>
+        </>
+      );
+  }
+}

--- a/src/widgets/sideBar/ui/TrendBarRowType.tsx
+++ b/src/widgets/sideBar/ui/TrendBarRowType.tsx
@@ -33,7 +33,9 @@ export default function TrendBarRowType({ rankChangeType, diffRank }: TrendBarRo
     case RankChangeType.NEW:
       return (
         <>
-          <span className="text-base font-medium text-white">NEW</span>
+          <span className="flex h-6 items-center rounded-lg bg-white/[16%] px-2 text-2xs font-semiBold text-white">
+            NEW
+          </span>
         </>
       );
   }


### PR DESCRIPTION
## 변경 사항
- 사이드바의 키워드가 표시되지 않던 오류 수정
- 키워드 클릭 시 해당 게시판으로 이동하도록 수정

## 세부 설명
실시간 인기 검색어 리스트 SSE 및 API의 필드로 boardId를 추가해주셔서 사이드바 수정하는 김에 함께 수정했습니다.
또한, hotboardList의 SSE 연결 해제 로직 삭제 부탁하셨던 건도 함께 진행했습니다.

## 관련 이슈
#140 #60 

## 스크린샷 (선택 사항)
<img width="392" height="728" alt="image" src="https://github.com/user-attachments/assets/483dacc7-5bad-40f5-9ecd-2a6206e86f1a" />


## 테스트 방법
.

## 체크리스트
- [x] 코드가 프로젝트의 코딩 스타일을 준수합니다
- [x] 자체 코드 리뷰를 수행했습니다
- [ ] 변경 사항에 대한 테스트가 추가/수정되었습니다
- [ ] 모든 테스트가 통과합니다
- [ ] 필요한 문서를 업데이트했습니다
