### PR TITLE
[FEAT] 게시물 상세 페이지 버그 이슈 및 SSR 적용

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,6 @@
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "dayjs": "^1.11.13",
-    "dompurify": "^3.2.6",
     "eventsource": "^4.0.0",
     "lodash": "^4.17.21",
     "lottie-react": "^2.4.1",

--- a/src/app/(main)/(boards)/board/[boardId]/post/[postId]/page.tsx
+++ b/src/app/(main)/(boards)/board/[boardId]/post/[postId]/page.tsx
@@ -1,11 +1,25 @@
+import { getQueryClient } from '@/providers/queryClient';
+import { axiosPost } from '@/shared/api';
+import type { PostDetailResponse } from '@/shared/types';
 import { Post } from '@/views/post';
+import { dehydrate, HydrationBoundary } from '@tanstack/react-query';
 
 export default async function Page({
   params,
 }: {
   params: Promise<{ boardId: string; postId: string }>;
 }) {
+  const queryClient = getQueryClient();
   const { boardId, postId } = await params;
 
-  return <Post postId={Number(postId)} boardId={Number(boardId)} />;
+  await queryClient.prefetchQuery({
+    queryKey: ['postDetail', Number(boardId), Number(postId)],
+    queryFn: () => axiosPost<PostDetailResponse>(Number(boardId), Number(postId)),
+  });
+
+  return (
+    <HydrationBoundary state={dehydrate(queryClient)}>
+      <Post postId={Number(postId)} boardId={Number(boardId)} />
+    </HydrationBoundary>
+  );
 }

--- a/src/app/(main)/(boards)/hotboard/[boardId]/post/[postId]/page.tsx
+++ b/src/app/(main)/(boards)/hotboard/[boardId]/post/[postId]/page.tsx
@@ -1,11 +1,24 @@
+import { getQueryClient } from '@/providers/queryClient';
+import { axiosPost } from '@/shared/api';
 import { Post } from '@/views/post';
+import type { PostDetailResponse } from '@/shared/types';
+import { dehydrate, HydrationBoundary } from '@tanstack/react-query';
 
 export default async function Page({
   params,
 }: {
   params: Promise<{ boardId: string; postId: string }>;
 }) {
+  const queryClient = getQueryClient();
   const { boardId, postId } = await params;
+  await queryClient.prefetchQuery({
+    queryKey: ['postDetail', Number(boardId), Number(postId)],
+    queryFn: () => axiosPost<PostDetailResponse>(Number(boardId), Number(postId)),
+  });
 
-  return <Post postId={Number(postId)} boardId={Number(boardId)} isHotBoard />;
+  return (
+    <HydrationBoundary state={dehydrate(queryClient)}>
+      <Post postId={Number(postId)} boardId={Number(boardId)} isHotBoard />
+    </HydrationBoundary>
+  );
 }

--- a/src/features/write/ui/PostEdit.tsx
+++ b/src/features/write/ui/PostEdit.tsx
@@ -25,6 +25,7 @@ const PostEdit = ({ boardId, postId, path }: postEditeProps) => {
   const { data, isLoading } = useQuery({
     queryKey: ['postDetail', boardId, postId],
     queryFn: () => axiosPost<PostDetailResponse>(boardId, postId),
+    select: (data) => data.data,
   });
   const post = data?.postInfoDto;
   const images = data?.imageInfos;

--- a/src/shared/api/axios/axios.ts
+++ b/src/shared/api/axios/axios.ts
@@ -1,7 +1,9 @@
 import axios from 'axios';
 
+const isDev = process.env.NODE_ENV === 'development';
+
 const axiosInstance = axios.create({
-  baseURL: process.env.NEXT_PUBLIC_REST_API_URL,
+  baseURL: isDev ? '' : process.env.NEXT_PUBLIC_REST_API_URL,
   withCredentials: true,
   timeout: 10000,
 });

--- a/src/shared/types/post.ts
+++ b/src/shared/types/post.ts
@@ -20,12 +20,14 @@ export interface PostInfo {
 }
 
 export interface PostDetailResponse {
-  message: string;
-  postInfoDto: PostDetail;
-  imageInfos: ImageInfo[];
+  data: {
+    postInfoDto: PostDetail;
+    imageInfos: ImageInfo[];
+  };
 }
 
 export interface PostDetail {
+  postId: number;
   boardName: string;
   title: string;
   writer: string;

--- a/src/views/post/ui/Post.tsx
+++ b/src/views/post/ui/Post.tsx
@@ -23,6 +23,8 @@ export default function Post({ postId, boardId, isHotBoard = false }: PostProps)
     select: (data) => data.data.postInfoDto,
   });
 
+  if (!post) return null;
+
   return (
     <div className="flex border-r border-gray-200 bg-white pr-8">
       <div className="flex w-full flex-col gap-y-8">

--- a/src/views/post/ui/Post.tsx
+++ b/src/views/post/ui/Post.tsx
@@ -1,6 +1,6 @@
 'use client';
 import { axiosPost } from '@/shared/api';
-import { PostDetailResponse } from '@/shared/types';
+import type { PostDetailResponse } from '@/shared/types';
 import { Comments } from '@/entities/comments';
 import { Content, Header } from '@/widgets/post';
 import { useQuery } from '@tanstack/react-query';
@@ -20,16 +20,14 @@ export default function Post({ postId, boardId, isHotBoard = false }: PostProps)
   const { data: post } = useQuery({
     queryKey: ['postDetail', boardId, postId],
     queryFn: () => axiosPost<PostDetailResponse>(boardId, postId),
-    select: (data) => data.postInfoDto,
+    select: (data) => data.data.postInfoDto,
   });
-
-  if (!post) return null;
 
   return (
     <div className="flex border-r border-gray-200 bg-white pr-8">
       <div className="flex w-full flex-col gap-y-8">
-        <Header post={post} isHotBoard={isHotBoard} boardId={boardId} postId={postId} />
-        <Content post={post} />
+        <Header post={post!} isHotBoard={isHotBoard} boardId={boardId} postId={postId} />
+        <Content post={post!} />
         <Comments boardId={boardId} postId={postId} />
       </div>
     </div>

--- a/src/widgets/post/ui/Content.tsx
+++ b/src/widgets/post/ui/Content.tsx
@@ -2,7 +2,6 @@
 
 import { PostDetail } from '@/shared/types';
 import { QuillDeltaToHtmlConverter } from 'quill-delta-to-html';
-import DOMPurify from 'dompurify';
 
 export default function Content({ post }: { post: PostDetail }) {
   // 임시 로직  Delta → HTML
@@ -25,7 +24,5 @@ export default function Content({ post }: { post: PostDetail }) {
     html = post.content;
   }
 
-  // XSS 방지 처리
-  html = DOMPurify.sanitize(html);
   return <div dangerouslySetInnerHTML={{ __html: html }} />;
 }


### PR DESCRIPTION
## 변경 사항
- 게시물 상세 페이지 SSR 적용
- 게시물 상세 페에지 SSR을 위해서 dompurify삭제 -> 추후 SSR 가능한 라이브러리 사용
- 게시물 상세 관련 API 타입추가
- 개발 서버일 경우 API호출을 /api로 하여 프록시를 통해 쿠키 전달

## 세부 설명
.

## 관련 이슈
Closes #144 

## 스크린샷 (선택 사항)
<img width="3840" height="2180" alt="image" src="https://github.com/user-attachments/assets/e0d0f3a2-ff86-4960-8348-85490c91cacc" />


## 테스트 방법
.

## 체크리스트
- [x] 코드가 프로젝트의 코딩 스타일을 준수합니다
- [x] 자체 코드 리뷰를 수행했습니다
- [ ] 변경 사항에 대한 테스트가 추가/수정되었습니다
- [ ] 모든 테스트가 통과합니다
- [ ] 필요한 문서를 업데이트했습니다
