### PR TITLE
[FEAT] Next.js 미들웨어 추가

### DIFF
--- a/src/app/(main)/(boards)/page.tsx
+++ b/src/app/(main)/(boards)/page.tsx
@@ -1,10 +1,15 @@
+import { LoginModal } from '@/features/login';
 import { Home } from '@/views/home';
 import { Suspense } from 'react';
 
-export default function Page() {
+export default async function Page({ searchParams }: { searchParams: Promise<{ login: string }> }) {
+  const { login } = await searchParams;
   return (
-    <Suspense>
-      <Home />
-    </Suspense>
+    <>
+      <Suspense>
+        <Home />
+      </Suspense>
+      <LoginModal open={Boolean(login)} />
+    </>
   );
 }

--- a/src/features/login/ui/LoginModal.tsx
+++ b/src/features/login/ui/LoginModal.tsx
@@ -2,7 +2,7 @@
 
 import React from 'react';
 import { Close } from './icons';
-import { usePathname } from 'next/navigation';
+import { usePathname, useRouter } from 'next/navigation';
 import { Modal } from '@/shared/ui';
 import GoogleLoginButton from './GoogleLoginButton';
 import KakaoLoginButton from './KakaoLoginButton';
@@ -13,14 +13,24 @@ interface LoginModalProps extends React.RefAttributes<HTMLDivElement> {
   /**@param {boolean} open 모달 여닫음 여부 */
   open: boolean;
   /**@param {() => void} onDimClick 모달 배경 클릭 시 함수 */
-  onClose: () => void;
+  onClose?: () => void;
 }
 
 export default function LoginModal({ open, onClose }: LoginModalProps) {
   // 개발 서버인지 유무 판단
   const isDev = process.env.NODE_ENV === 'development';
 
+  const router = useRouter();
   const pathname = usePathname();
+
+  // onClose를 넘겨줄 경우 state로 관리, onClose를 안넘겨줄경우 url로 관리
+  const handleClose = () => {
+    if (onClose) {
+      onClose();
+    } else {
+      router.replace('/');
+    }
+  };
 
   if (!open) return;
 
@@ -29,9 +39,9 @@ export default function LoginModal({ open, onClose }: LoginModalProps) {
   );
 
   return (
-    <Modal onClose={onClose}>
+    <Modal onClose={handleClose}>
       <span className="relative flex h-fit w-[540px] flex-col gap-y-8 rounded-[2rem] bg-white px-8 py-10">
-        <span onClick={onClose} className="absolute right-6 top-6 cursor-pointer">
+        <span onClick={handleClose} className="absolute right-6 top-6 cursor-pointer">
           <Close />
         </span>
         <div className="flex w-full flex-col justify-center gap-y-8 py-8">
@@ -47,7 +57,7 @@ export default function LoginModal({ open, onClose }: LoginModalProps) {
           <GoogleLoginButton redirectPath={encodedUri} />
           <KakaoLoginButton redirectPath={encodedUri} />
           <NaverLoginButton redirectPath={encodedUri} />
-          {isDev && <TestLoginButton onClose={onClose} />}
+          {isDev && <TestLoginButton onClose={handleClose} />}
         </div>
       </span>
     </Modal>

--- a/src/features/login/ui/RequireLoginModal.tsx
+++ b/src/features/login/ui/RequireLoginModal.tsx
@@ -1,3 +1,4 @@
+'use client';
 import { Modal } from '@/shared/ui';
 import { usePathname } from 'next/navigation';
 import React from 'react';

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,0 +1,21 @@
+import { NextResponse } from 'next/server';
+import type { NextRequest } from 'next/server';
+
+export function middleware(request: NextRequest) {
+  // 요청에서 'accesstoken' 쿠키를 가져옴
+  const accesstoken = request.cookies.get('access_token');
+
+  // 요청에서 'refreshtoken' 쿠키를 가져옴
+  const refreshtoken = request.cookies.get('access_token');
+
+  // 액세스 토큰 또는 리프레시 토큰이 없을 경우 로그인 페이지로 리다이렉트
+  if (!accesstoken?.value || !refreshtoken?.value) {
+    return NextResponse.redirect(new URL('/?login=true', request.url));
+  }
+
+  return NextResponse.next();
+}
+
+export const config = {
+  matcher: ['/board/:boardId/write', '/hotboard/:boardId/write', '/mypage/:path*'],
+};


### PR DESCRIPTION
## 변경 사항
- next.js 미들웨어 추가
- RequireLoginModal 컴포넌트 'use client' 추가
- `/` 페이지에 로그인 모달 추가 

## 세부 설명
- `/?login=true` 로 메인페이지에서 로그인 모달을 관리할 수 있게 추가하였습니다.
- LoginModal에서 onClose를 props로 주지 않을 경우 메인페이지로 이동하게 추가하였습니다. (`/?login=true` 페이지에서 닫기버튼을 통해서 `/` 으로 돌아가기 위함)
-  RequireLoginModal 컴포넌트에서 'use client' 을 붙이지 않으면 오류가 생겨서 추가해두었습니다.
- next.js 미들웨어를 통해서 글작성 페이지 / 마이페이지로 이동시에 토큰이 없을 경우 `/?login=true` 으로 리다이렉트되게 설정했습니다. (추후 토큰 재발급 로직 추가 예정)

## 관련 이슈
Close #154 

## 스크린샷 (선택 사항)
.

## 테스트 방법
.

## 체크리스트
- [x] 코드가 프로젝트의 코딩 스타일을 준수합니다
- [x] 자체 코드 리뷰를 수행했습니다
- [ ] 변경 사항에 대한 테스트가 추가/수정되었습니다
- [ ] 모든 테스트가 통과합니다
- [ ] 필요한 문서를 업데이트했습니다
