### PR TITLE
[FEAT] 로그인 모달 이미지 변경

### DIFF
--- a/src/features/login/ui/RequireLoginModal.tsx
+++ b/src/features/login/ui/RequireLoginModal.tsx
@@ -5,6 +5,7 @@ import { Close } from './icons';
 import GoogleLoginButton from './GoogleLoginButton';
 import KakaoLoginButton from './KakaoLoginButton';
 import NaverLoginButton from './NaverLoginButton';
+import Image from 'next/image';
 
 interface LoginModalProps extends React.RefAttributes<HTMLDivElement> {
   /**@param {boolean} open 모달 여닫음 여부 */
@@ -27,8 +28,8 @@ export default function RequireLoginModal({ open, onClose }: LoginModalProps) {
         <span onClick={onClose} className="absolute right-6 top-6 cursor-pointer">
           <Close />
         </span>
-        <div className="flex w-full flex-col justify-center gap-y-8">
-          <span className="text-center font-himpun text-5xl text-gray-800">Trendnow</span>
+        <div className="flex w-full flex-col items-center justify-center gap-y-8">
+          <Image src="/images/loginAnimation.gif" alt="로그인 이미지" height={160} width={256} />
           <span className="flex flex-col gap-y-3">
             <span className="text-center text-xl font-bold text-gray-900">
               로그인이 필요한 서비스입니다.


### PR DESCRIPTION
## 변경 사항
피그마 디자인에 맞춰 제공 받은 GIF를 로그인 모달에 적용 시켰습니다.

## 세부 설명
.

## 관련 이슈
resolve #151 

## 스크린샷 (선택 사항)
<img width="1920" height="992" alt="image" src="https://github.com/user-attachments/assets/91b795ef-47b9-422e-9a35-30b6f8685936" />

## 테스트 방법
.

## 체크리스트
- [x] 코드가 프로젝트의 코딩 스타일을 준수합니다
- [x] 자체 코드 리뷰를 수행했습니다
- [ ] 변경 사항에 대한 테스트가 추가/수정되었습니다
- [ ] 모든 테스트가 통과합니다
- [ ] 필요한 문서를 업데이트했습니다
