### PR TITLE
[FIX] 글쓰기 버튼 로그인 체크

### DIFF
--- a/src/features/board/ui/BoardWriteButton.tsx
+++ b/src/features/board/ui/BoardWriteButton.tsx
@@ -2,7 +2,6 @@
 
 import React, { useState } from 'react';
 import { Pencil24, PrimaryButton } from '@/shared/ui';
-import { useUserStore } from '@/shared/store';
 import { axiosCheckWriteCooldown } from '@/shared/api';
 import { WriteCooldownResponse } from '@/shared/types';
 import { useRouter } from 'next/navigation';
@@ -15,22 +14,21 @@ interface BoardWriteButtonProps {
 
 export default function BoardWriteButton({ href, boardId }: BoardWriteButtonProps) {
   const router = useRouter();
-  const { isAuthenticated } = useUserStore();
 
   const [isLoginModalOpen, setIsLoginModalOpen] = useState(false);
 
   const handleWriteButton = async () => {
-    if (!isAuthenticated) {
+    try {
+      const result = await axiosCheckWriteCooldown<WriteCooldownResponse>(boardId);
+
+      if (result.canWritePost) {
+        router.push(href);
+      } else {
+        alert(`${result.cooldownSeconds}초 후 게시글 작성이 가능합니다.`);
+      }
+    } catch {
       setIsLoginModalOpen(true);
       return;
-    }
-
-    const result = await axiosCheckWriteCooldown<WriteCooldownResponse>(boardId);
-
-    if (result.canWritePost) {
-      router.push(href);
-    } else {
-      alert(`${result.cooldownSeconds}초 후 게시글 작성이 가능합니다.`);
     }
   };
 


### PR DESCRIPTION
## 변경 사항
글쓰기 버튼 클릭 시 로그인 여부 확인하는 로직을 쿠키 저장 방식에 맞춰 수정했습니다.

## 세부 설명
현재 백엔드에서 access token 미포함시 500 에러를 응답하고 있습니다.
따라서, 일단 모든 에러에 대해서 로그인 모달을 띄어주는 방식으로 수정했습니다.
필요하다면 추후에 401 에러를 응답하도록 수정되었을 때 그에 맞춰 수정해도 될 것 같습니다.

## 관련 이슈
closes #157 

## 스크린샷 (선택 사항)
.

## 테스트 방법
.

## 체크리스트
- [x] 코드가 프로젝트의 코딩 스타일을 준수합니다
- [x] 자체 코드 리뷰를 수행했습니다
- [ ] 변경 사항에 대한 테스트가 추가/수정되었습니다
- [ ] 모든 테스트가 통과합니다
- [ ] 필요한 문서를 업데이트했습니다
