### PR TITLE
[FIX] 헤더의 사용자 정보 인증을 쿠키 기반으로 변경

### DIFF
--- a/src/features/header/ui/User.tsx
+++ b/src/features/header/ui/User.tsx
@@ -11,7 +11,6 @@ import {
 import { LoginModal } from '@/features/login';
 import { useQuery, useQueryClient } from '@tanstack/react-query';
 import { useRouter } from 'next/navigation';
-import { useUserStore } from '@/shared/store';
 import { axiosUserProfile } from '@/shared/api';
 import { UserProfile } from '@/shared/types';
 import Link from 'next/link';
@@ -20,7 +19,6 @@ export default function User() {
   const queryClient = useQueryClient();
   const router = useRouter();
 
-  const { logout, isAuthenticated, accessToken } = useUserStore();
   const [isModalOpen, setIsModalOpen] = useState<boolean>(false);
 
   const handleModalOpen = () => {
@@ -31,14 +29,13 @@ export default function User() {
     setIsModalOpen(false);
   };
 
-  const { data } = useQuery<UserProfile>({
+  const { data: user, isError } = useQuery<UserProfile>({
     queryKey: ['userInfo'],
     queryFn: () => axiosUserProfile(),
-    enabled: !!accessToken,
   });
 
   // 로그인 안되어있을때
-  if (!isAuthenticated) {
+  if (!user || isError) {
     return (
       <>
         <PrimaryButton
@@ -60,7 +57,7 @@ export default function User() {
         className="flex h-10 select-none items-center gap-x-2.5 text-nowrap rounded-full bg-gray-100 py-2.5 pl-2.5 pr-3.5 text-base font-medium"
       >
         <UserProfile28 />
-        {data?.nickname}
+        {user?.nickname}
       </Link>
 
       <DropdownMenu
@@ -88,7 +85,6 @@ export default function User() {
             const confirmSignout = confirm('정말 로그아웃 하실 건가요?');
 
             if (confirmSignout) {
-              logout();
               // 진행 중 요청 취소
               await queryClient.cancelQueries();
 

--- a/src/features/header/ui/UserServerComponent.tsx
+++ b/src/features/header/ui/UserServerComponent.tsx
@@ -1,0 +1,19 @@
+import User from '@/features/header/ui/User';
+import { axiosUserProfile } from '@/shared/api';
+import { dehydrate, HydrationBoundary, QueryClient } from '@tanstack/react-query';
+import { cookies } from 'next/headers';
+
+export default async function UserServerComponent() {
+  const queryClient = new QueryClient();
+  const cookieStore = await cookies();
+  await queryClient.prefetchQuery({
+    queryKey: ['userInfo'],
+    queryFn: () => axiosUserProfile(cookieStore.toString()),
+  });
+
+  return (
+    <HydrationBoundary state={dehydrate(queryClient)}>
+      <User />
+    </HydrationBoundary>
+  );
+}

--- a/src/features/header/ui/index.ts
+++ b/src/features/header/ui/index.ts
@@ -1,3 +1,3 @@
-import User from './User';
+import UserServerComponent from './UserServerComponent';
 
-export { User };
+export { UserServerComponent };

--- a/src/shared/api/axios/axios.ts
+++ b/src/shared/api/axios/axios.ts
@@ -1,4 +1,4 @@
-import axios from 'axios';
+import axios, { AxiosRequestConfig } from 'axios';
 
 const axiosInstance = axios.create({
   baseURL: process.env.NEXT_PUBLIC_REST_API_URL,
@@ -96,8 +96,20 @@ export const axiosNaverAccessToken = async <T>(code: string, state: string): Pro
 //#endregion
 
 //#region 회원 정보
-export const axiosUserProfile = async <T>(): Promise<T> =>
-  (await axiosInstance.get('/api/v1/member/me')).data;
+export const axiosUserProfile = async <T>(cookie?: string): Promise<T> => {
+  // 요청에 사용할 설정 객체
+  const config: AxiosRequestConfig = {};
+
+  // cookie 인자가 전달된 경우 (서버 환경)에만 헤더를 추가
+  if (cookie) {
+    config.headers = {
+      Cookie: cookie,
+    };
+  }
+
+  const response = await axiosInstance.get('/api/v1/member/me', config);
+  return response.data;
+};
 
 export const axiosEditUsername = async <T>(nickname: string): Promise<T> =>
   (await axiosInstance.patch('/api/v1/member/login/naver', JSON.stringify({ nickname }))).data;

--- a/src/widgets/header/ui/AppBar.tsx
+++ b/src/widgets/header/ui/AppBar.tsx
@@ -1,8 +1,8 @@
 import { Trendnow } from '@/shared/ui/';
 import Link from 'next/link';
-import { User } from '@/features/header';
 import { SearchBar } from '@/features/searchBar';
 import { Suspense } from 'react';
+import { UserServerComponent } from '@/features/header';
 
 const Appbar = () => {
   return (
@@ -15,7 +15,7 @@ const Appbar = () => {
           <SearchBar />
         </Suspense>
         <div className="flex w-[12.5rem] justify-end">
-          <User />
+          <UserServerComponent />
         </div>
       </div>
     </header>


### PR DESCRIPTION
## 변경 사항
- 헤더의 사용자 정보 인증을 쿠키 기반으로 변경
- `UserServerComponent`에서 사용자 정보를 미리 가져온 후(prefetch) `User` 컴포넌트로 Hydration하여, 초기 렌더링 시 사용자 정보가 즉시 표시
- 서버 환경에서는 API 요청 시 쿠키가 자동 전송되지 않는 문제가 있어서, axiosUserProfile에 쿠키 직접 주입

## 세부 설명
- 현재 백엔드에서 로그아웃 API 작업중에 있어서 로그아웃이 안되는 이슈가 있습니다.

## 관련 이슈
Close #159 

## 스크린샷 (선택 사항)
<img width="3456" height="2412" alt="image" src="https://github.com/user-attachments/assets/9250f459-90d6-4d35-8e4c-04b03647e3b9" />


## 테스트 방법
.

## 체크리스트
- [x] 코드가 프로젝트의 코딩 스타일을 준수합니다
- [x] 자체 코드 리뷰를 수행했습니다
- [ ] 변경 사항에 대한 테스트가 추가/수정되었습니다
- [ ] 모든 테스트가 통과합니다
- [ ] 필요한 문서를 업데이트했습니다
