### PR TITLE
[FIX] 글 작성 / 수정 후 상세 페이지로 이동

### DIFF
--- a/src/app/(main)/(boards)/board/[boardId]/post/[postId]/edit/page.tsx
+++ b/src/app/(main)/(boards)/board/[boardId]/post/[postId]/edit/page.tsx
@@ -9,7 +9,7 @@ export default async function Page({
 }) {
   const { boardId, postId } = await params;
 
-  const path = `/board/${boardId}`;
+  const basePath = `/board`;
   return (
     <div className="flex flex-col gap-4">
       <BoardName
@@ -24,7 +24,7 @@ export default async function Page({
           />
         }
       />
-      <PostEdit boardId={Number(boardId)} postId={Number(postId)} path={path} />
+      <PostEdit boardId={Number(boardId)} postId={Number(postId)} basePath={basePath} />
     </div>
   );
 }

--- a/src/app/(main)/(boards)/board/[boardId]/write/page.tsx
+++ b/src/app/(main)/(boards)/board/[boardId]/write/page.tsx
@@ -1,14 +1,12 @@
 import { BoardName } from '@/entities/board';
 import { PostWrite } from '@/features/write';
-// import { LoginGuard } from '@/shared/middleware';
 import Image from 'next/image';
 
 export default async function Page({ params }: { params: Promise<{ boardId: string }> }) {
   const { boardId } = await params;
-  const path = `/board/${boardId}`;
+  const basePath = `/board`;
 
   return (
-    // <LoginGuard redirectPath={path}>
     <div className="flex flex-col gap-4">
       <BoardName
         boardId={Number(boardId)}
@@ -22,8 +20,7 @@ export default async function Page({ params }: { params: Promise<{ boardId: stri
           />
         }
       />
-      <PostWrite boardId={Number(boardId)} path={path} />
+      <PostWrite boardId={Number(boardId)} basePath={basePath} />
     </div>
-    // </LoginGuard>
   );
 }

--- a/src/app/(main)/(boards)/hotboard/[boardId]/post/[postId]/edit/page.tsx
+++ b/src/app/(main)/(boards)/hotboard/[boardId]/post/[postId]/edit/page.tsx
@@ -9,7 +9,7 @@ export default async function Page({
 }) {
   const { boardId, postId } = await params;
 
-  const path = `/hotboard/${boardId}`;
+  const basePath = `/hotboard`;
   return (
     <div className="flex flex-col gap-4">
       <BoardName
@@ -25,7 +25,7 @@ export default async function Page({
           />
         }
       />
-      <PostEdit boardId={Number(boardId)} postId={Number(postId)} path={path} />
+      <PostEdit boardId={Number(boardId)} postId={Number(postId)} basePath={basePath} />
     </div>
   );
 }

--- a/src/app/(main)/(boards)/hotboard/[boardId]/write/page.tsx
+++ b/src/app/(main)/(boards)/hotboard/[boardId]/write/page.tsx
@@ -1,13 +1,11 @@
 import { BoardName } from '@/entities/board';
 import { PostWrite } from '@/features/write';
-// import { LoginGuard } from '@/shared/middleware';
 import Image from 'next/image';
 
 export default async function Page({ params }: { params: Promise<{ boardId: string }> }) {
   const { boardId } = await params;
-  const path = `/hotboard/${boardId}`;
+  const basePath = `/hotboard`;
   return (
-    // <LoginGuard redirectPath={path}>
     <div className="flex flex-col gap-4">
       <BoardName
         boardId={Number(boardId)}
@@ -22,8 +20,7 @@ export default async function Page({ params }: { params: Promise<{ boardId: stri
           />
         }
       />
-      <PostWrite boardId={Number(boardId)} path={path} />
+      <PostWrite boardId={Number(boardId)} basePath={basePath} />
     </div>
-    // </LoginGuard>
   );
 }

--- a/src/features/write/ui/PostEdit.tsx
+++ b/src/features/write/ui/PostEdit.tsx
@@ -13,10 +13,10 @@ interface postEditeProps {
   /** 게시물 id */
   postId: number;
   /** path */
-  path: string;
+  basePath: string;
 }
 
-const PostEdit = ({ boardId, postId, path }: postEditeProps) => {
+const PostEdit = ({ boardId, postId, basePath }: postEditeProps) => {
   const router = useRouter();
   const editorRef = useRef<RichTextEditorHandle>(null); // 에디터 내용(DOM)이나 메서드에 접근하기 위한 ref
   const titleRef = useRef<HTMLInputElement>(null); // 제목 저장하는 ref
@@ -59,7 +59,7 @@ const PostEdit = ({ boardId, postId, path }: postEditeProps) => {
       imageIds,
       deleteImageIdList
     );
-    router.push(`${path}`);
+    router.push(`${basePath}/${boardId}/post/${postId}`);
   };
 
   // 권한 체크 → 본인 글 아니면 alert + 리디렉트
@@ -68,9 +68,9 @@ const PostEdit = ({ boardId, postId, path }: postEditeProps) => {
 
     if (!post.myPost) {
       alert('본인 게시물만 수정할 수 있습니다.');
-      router.push(`${path}/post/${postId}`);
+      router.push(`${basePath}/${boardId}/post/${postId}`);
     }
-  }, [isLoading, post, path, router]);
+  }, [isLoading, post, basePath, router]);
 
   // post 데이터가 로드되면 제목 input과 이미지 ID 초기값 설정
   useEffect(() => {

--- a/src/features/write/ui/PostWrite.tsx
+++ b/src/features/write/ui/PostWrite.tsx
@@ -2,7 +2,7 @@
 import processDelta from '../lib/processDelta';
 import Write from './Write';
 import { axiosUploadPost } from '@/shared/api';
-import { RichTextEditorHandle } from '@/shared/types';
+import { PostDetailResponse, RichTextEditorHandle } from '@/shared/types';
 import { useRouter } from 'next/navigation';
 import { useRef } from 'react';
 
@@ -10,10 +10,10 @@ interface PostWriteProps {
   /** 게시판 id */
   boardId: number;
   /** path */
-  path: string;
+  basePath: string;
 }
 
-const PostWrite = ({ boardId, path }: PostWriteProps) => {
+const PostWrite = ({ boardId, basePath }: PostWriteProps) => {
   const router = useRouter();
   const editorRef = useRef<RichTextEditorHandle>(null); // 에디터 내용(DOM)이나 메서드에 접근하기 위한 ref
   const titleRef = useRef<HTMLInputElement>(null); // 제목 저장하는 ref
@@ -37,8 +37,14 @@ const PostWrite = ({ boardId, path }: PostWriteProps) => {
     }
 
     const { newDelta, imageIds } = processDelta(delta!, uploadsByTempId!);
-    await axiosUploadPost(boardId, title, JSON.stringify(newDelta), imageIds);
-    router.push(`${path}`);
+    const response = await axiosUploadPost<PostDetailResponse>(
+      boardId,
+      title,
+      JSON.stringify(newDelta),
+      imageIds
+    );
+    const posdId = response.data.postInfoDto.postId;
+    router.push(`${basePath}/${boardId}/post/${posdId}`);
   };
   return <Write titleRef={titleRef} editorRef={editorRef} onSubmit={handleSubmit} />;
 };

--- a/src/shared/api/axios/axios.ts
+++ b/src/shared/api/axios/axios.ts
@@ -147,7 +147,7 @@ export const axiosUploadPost = async <T>(
   content: string,
   imageIds: number[]
 ): Promise<T> =>
-  await axiosInstance.post(`/api/v1/boards/${boardId}/posts`, { title, content, imageIds });
+  (await axiosInstance.post(`/api/v1/boards/${boardId}/posts`, { title, content, imageIds })).data;
 
 export const axiosUpdatePost = async <T>(
   boardId: number,


### PR DESCRIPTION
## 변경 사항
- 주석 처리 되어 있던 LoginGuard 컴포넌트를 삭제
- 기존 path prop을 basePath로 명확하게 변경하고, 상세 경로는 컴포넌트 내부에서 설정하도록 구조를 변경
- 글 작성 및 수정 완료 후, 해당 상세 페이지로 이동

## 세부 설명
.

## 관련 이슈
close #117 

## 스크린샷 (선택 사항)
.

## 테스트 방법
.

## 체크리스트
- [x] 코드가 프로젝트의 코딩 스타일을 준수합니다
- [x] 자체 코드 리뷰를 수행했습니다
- [ ] 변경 사항에 대한 테스트가 추가/수정되었습니다
- [ ] 모든 테스트가 통과합니다
- [ ] 필요한 문서를 업데이트했습니다
