### PR TITLE
[FEAT] 에디터 SSR 렌더링을 위한 폴백 UI 추가

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -5,12 +5,17 @@
 .ql-toolbar.ql-snow {
   border-top-left-radius: 12px !important;
   border-top-right-radius: 12px !important;
+  border: 1px solid #e4e8ed !important;
+  background-color: #f2f4f7 !important;
 }
 
 .ql-container.ql-snow {
   border-bottom-left-radius: 12px !important;
   border-bottom-right-radius: 12px !important;
   background-color: white !important;
+  border-left: 1px solid #e4e8ed !important;
+  border-right: 1px solid #e4e8ed !important;
+  border-bottom: 1px solid #e4e8ed !important;
 }
 
 .ql-editor {

--- a/src/features/write/ui/RichTextEditor.tsx
+++ b/src/features/write/ui/RichTextEditor.tsx
@@ -108,7 +108,9 @@ const RichTextEditor = forwardRef<RichTextEditorHandle, RichTextEditorProps>(
           toolbar: {
             container: [
               [{ header: [1, 2, 3, false] }],
+              [{ color: [] }, { background: [] }],
               ['bold', 'italic', 'underline', 'strike'],
+              [{ align: [] }],
               [{ list: 'ordered' }, { list: 'bullet' }],
               ['link', 'image'],
             ],

--- a/src/features/write/ui/StaticEditor.tsx
+++ b/src/features/write/ui/StaticEditor.tsx
@@ -1,0 +1,226 @@
+export default function StaticEditor() {
+  return (
+    <div className="h-[344.37px] rounded-xl">
+      <div className="h-[44.37px]">
+        <div id="custom-toolbar" role="toolbar" className="ql-toolbar ql-snow border-none">
+          <span className="ql-formats">
+            <span className="ql-header ql-picker">
+              <span className="ql-picker-label">
+                <svg viewBox="0 0 18 18">
+                  <polygon className="ql-stroke" points="7 11 9 13 11 11 7 11"></polygon>
+                  <polygon className="ql-stroke" points="7 7 9 5 11 7 7 7"></polygon>
+                </svg>
+              </span>
+            </span>
+          </span>
+          <span className="ql-formats">
+            <span className="ql-color ql-picker ql-color-picker">
+              <span
+                className="ql-picker-label"
+                role="button"
+                aria-expanded="false"
+                aria-controls="ql-picker-options-1"
+              >
+                <svg viewBox="0 0 18 18">
+                  <line
+                    className="ql-color-label ql-stroke ql-transparent"
+                    x1="3"
+                    x2="15"
+                    y1="15"
+                    y2="15"
+                  ></line>
+                  <polyline className="ql-stroke" points="5.5 11 9 3 12.5 11"></polyline>
+                  <line className="ql-stroke" x1="11.63" x2="6.38" y1="9" y2="9"></line>
+                </svg>
+              </span>
+            </span>
+            <span className="ql-background ql-picker ql-color-picker">
+              <span className="ql-picker-label">
+                <svg viewBox="0 0 18 18">
+                  <g className="ql-fill ql-color-label">
+                    <polygon points="6 6.868 6 6 5 6 5 7 5.942 7 6 6.868"></polygon>
+                    <rect height="1" width="1" x="4" y="4"></rect>
+                    <polygon points="6.817 5 6 5 6 6 6.38 6 6.817 5"></polygon>
+                    <rect height="1" width="1" x="2" y="6"></rect>
+                    <rect height="1" width="1" x="3" y="5"></rect>
+                    <rect height="1" width="1" x="4" y="7"></rect>
+                    <polygon points="4 11.439 4 11 3 11 3 12 3.755 12 4 11.439"></polygon>
+                    <rect height="1" width="1" x="2" y="12"></rect>
+                    <rect height="1" width="1" x="2" y="9"></rect>
+                    <rect height="1" width="1" x="2" y="15"></rect>
+                    <polygon points="4.63 10 4 10 4 11 4.192 11 4.63 10"></polygon>
+                    <rect height="1" width="1" x="3" y="8"></rect>
+                    <path d="M10.832,4.2L11,4.582V4H10.708A1.948,1.948,0,0,1,10.832,4.2Z"></path>
+                    <path d="M7,4.582L7.168,4.2A1.929,1.929,0,0,1,7.292,4H7V4.582Z"></path>
+                    <path d="M8,13H7.683l-0.351.8a1.933,1.933,0,0,1-.124.2H8V13Z"></path>
+                    <rect height="1" width="1" x="12" y="2"></rect>
+                    <rect height="1" width="1" x="11" y="3"></rect>
+                    <path d="M9,3H8V3.282A1.985,1.985,0,0,1,9,3Z"></path>
+                    <rect height="1" width="1" x="2" y="3"></rect>
+                    <rect height="1" width="1" x="6" y="2"></rect>
+                    <rect height="1" width="1" x="3" y="2"></rect>
+                    <rect height="1" width="1" x="5" y="3"></rect>
+                    <rect height="1" width="1" x="9" y="2"></rect>
+                    <rect height="1" width="1" x="15" y="14"></rect>
+                    <polygon points="13.447 10.174 13.469 10.225 13.472 10.232 13.808 11 14 11 14 10 13.37 10 13.447 10.174"></polygon>
+                    <rect height="1" width="1" x="13" y="7"></rect>
+                    <rect height="1" width="1" x="15" y="5"></rect>
+                    <rect height="1" width="1" x="14" y="6"></rect>
+                    <rect height="1" width="1" x="15" y="8"></rect>
+                    <rect height="1" width="1" x="14" y="9"></rect>
+                    <path d="M3.775,14H3v1H4V14.314A1.97,1.97,0,0,1,3.775,14Z"></path>
+                    <rect height="1" width="1" x="14" y="3"></rect>
+                    <polygon points="12 6.868 12 6 11.62 6 12 6.868"></polygon>
+                    <rect height="1" width="1" x="15" y="2"></rect>
+                    <rect height="1" width="1" x="12" y="5"></rect>
+                    <rect height="1" width="1" x="13" y="4"></rect>
+                    <polygon points="12.933 9 13 9 13 8 12.495 8 12.933 9"></polygon>
+                    <rect height="1" width="1" x="9" y="14"></rect>
+                    <rect height="1" width="1" x="8" y="15"></rect>
+                    <path d="M6,14.926V15H7V14.316A1.993,1.993,0,0,1,6,14.926Z"></path>
+                    <rect height="1" width="1" x="5" y="15"></rect>
+                    <path d="M10.668,13.8L10.317,13H10v1h0.792A1.947,1.947,0,0,1,10.668,13.8Z"></path>
+                    <rect height="1" width="1" x="11" y="15"></rect>
+                    <path d="M14.332,12.2a1.99,1.99,0,0,1,.166.8H15V12H14.245Z"></path>
+                    <rect height="1" width="1" x="14" y="15"></rect>
+                    <rect height="1" width="1" x="15" y="11"></rect>
+                  </g>
+                  <polyline className="ql-stroke" points="5.5 13 9 5 12.5 13"></polyline>
+                  <line className="ql-stroke" x1="11.63" x2="6.38" y1="11" y2="11"></line>
+                </svg>
+              </span>
+            </span>
+          </span>
+          <span className="ql-formats">
+            <button className="ql-bold">
+              <svg viewBox="0 0 18 18">
+                <path
+                  className="ql-stroke"
+                  d="M5,4H9.5A2.5,2.5,0,0,1,12,6.5v0A2.5,2.5,0,0,1,9.5,9H5A0,0,0,0,1,5,9V4A0,0,0,0,1,5,4Z"
+                ></path>
+                <path
+                  className="ql-stroke"
+                  d="M5,9h5.5A2.5,2.5,0,0,1,13,11.5v0A2.5,2.5,0,0,1,10.5,14H5a0,0,0,0,1,0,0V9A0,0,0,0,1,5,9Z"
+                ></path>
+              </svg>
+            </button>
+            <button className="ql-italic">
+              <svg viewBox="0 0 18 18">
+                <line className="ql-stroke" x1="7" x2="13" y1="4" y2="4"></line>
+                <line className="ql-stroke" x1="5" x2="11" y1="14" y2="14"></line>
+                <line className="ql-stroke" x1="8" x2="10" y1="14" y2="4"></line>
+              </svg>
+            </button>
+            <button className="ql-underline">
+              <svg viewBox="0 0 18 18">
+                <path
+                  className="ql-stroke"
+                  d="M5,3V9a4.012,4.012,0,0,0,4,4H9a4.012,4.012,0,0,0,4-4V3"
+                ></path>
+                <rect
+                  className="ql-fill"
+                  height="1"
+                  rx="0.5"
+                  ry="0.5"
+                  width="12"
+                  x="3"
+                  y="15"
+                ></rect>
+              </svg>
+            </button>
+            <button className="ql-strike">
+              <svg viewBox="0 0 18 18">
+                <line className="ql-stroke ql-thin" x1="15.5" x2="2.5" y1="8.5" y2="9.5"></line>
+                <path
+                  className="ql-fill"
+                  d="M9.007,8C6.542,7.791,6,7.519,6,6.5,6,5.792,7.283,5,9,5c1.571,0,2.765.679,2.969,1.309a1,1,0,0,0,1.9-.617C13.356,4.106,11.354,3,9,3,6.2,3,4,4.538,4,6.5a3.2,3.2,0,0,0,.5,1.843Z"
+                ></path>
+                <path
+                  className="ql-fill"
+                  d="M8.984,10C11.457,10.208,12,10.479,12,11.5c0,0.708-1.283,1.5-3,1.5-1.571,0-2.765-.679-2.969-1.309a1,1,0,1,0-1.9.617C4.644,13.894,6.646,15,9,15c2.8,0,5-1.538,5-3.5a3.2,3.2,0,0,0-.5-1.843Z"
+                ></path>
+              </svg>
+            </button>
+          </span>
+          <span className="ql-formats">
+            <span className="ql-align ql-picker ql-icon-picker">
+              <span className="ql-picker-label">
+                <svg viewBox="0 0 18 18">
+                  <line className="ql-stroke" x1="3" x2="15" y1="9" y2="9"></line>
+                  <line className="ql-stroke" x1="3" x2="13" y1="14" y2="14"></line>
+                  <line className="ql-stroke" x1="3" x2="9" y1="4" y2="4"></line>
+                </svg>
+              </span>
+            </span>
+          </span>
+          <span className="ql-formats">
+            <button className="ql-list">
+              <svg viewBox="0 0 18 18">
+                <line className="ql-stroke" x1="7" x2="15" y1="4" y2="4"></line>
+                <line className="ql-stroke" x1="7" x2="15" y1="9" y2="9"></line>
+                <line className="ql-stroke" x1="7" x2="15" y1="14" y2="14"></line>
+                <line className="ql-stroke ql-thin" x1="2.5" x2="4.5" y1="5.5" y2="5.5"></line>
+                <path
+                  className="ql-fill"
+                  d="M3.5,6A0.5,0.5,0,0,1,3,5.5V3.085l-0.276.138A0.5,0.5,0,0,1,2.053,3c-0.124-.247-0.023-0.324.224-0.447l1-.5A0.5,0.5,0,0,1,4,2.5v3A0.5,0.5,0,0,1,3.5,6Z"
+                ></path>
+                <path
+                  className="ql-stroke ql-thin"
+                  d="M4.5,10.5h-2c0-.234,1.85-1.076,1.85-2.234A0.959,0.959,0,0,0,2.5,8.156"
+                ></path>
+                <path
+                  className="ql-stroke ql-thin"
+                  d="M2.5,14.846a0.959,0.959,0,0,0,1.85-.109A0.7,0.7,0,0,0,3.75,14a0.688,0.688,0,0,0,.6-0.736,0.959,0.959,0,0,0-1.85-.109"
+                ></path>
+              </svg>
+            </button>
+            <button
+              type="button"
+              className="ql-list"
+              aria-pressed="false"
+              value="bullet"
+              aria-label="list: bullet"
+            >
+              <svg viewBox="0 0 18 18">
+                <line className="ql-stroke" x1="6" x2="15" y1="4" y2="4"></line>
+                <line className="ql-stroke" x1="6" x2="15" y1="9" y2="9"></line>
+                <line className="ql-stroke" x1="6" x2="15" y1="14" y2="14"></line>
+                <line className="ql-stroke" x1="3" x2="3" y1="4" y2="4"></line>
+                <line className="ql-stroke" x1="3" x2="3" y1="9" y2="9"></line>
+                <line className="ql-stroke" x1="3" x2="3" y1="14" y2="14"></line>
+              </svg>
+            </button>
+          </span>
+          <span className="ql-formats">
+            <button className="ql-link">
+              <svg viewBox="0 0 18 18">
+                <line className="ql-stroke" x1="7" x2="11" y1="7" y2="11"></line>
+                <path
+                  className="ql-even ql-stroke"
+                  d="M8.9,4.577a3.476,3.476,0,0,1,.36,4.679A3.476,3.476,0,0,1,4.577,8.9C3.185,7.5,2.035,6.4,4.217,4.217S7.5,3.185,8.9,4.577Z"
+                ></path>
+                <path
+                  className="ql-even ql-stroke"
+                  d="M13.423,9.1a3.476,3.476,0,0,0-4.679-.36,3.476,3.476,0,0,0,.36,4.679c1.392,1.392,2.5,2.542,4.679.36S14.815,10.5,13.423,9.1Z"
+                ></path>
+              </svg>
+            </button>
+            <button className="ql-image">
+              <svg viewBox="0 0 18 18">
+                <rect className="ql-stroke" height="10" width="12" x="3" y="4"></rect>
+                <circle className="ql-fill" cx="6" cy="7" r="1"></circle>
+                <polyline
+                  className="ql-even ql-fill"
+                  points="5 12 5 11 7 9 8 10 11 7 13 9 13 12 5 12"
+                ></polyline>
+              </svg>
+            </button>
+          </span>
+        </div>
+      </div>
+      <div className="h-full border-b border-l border-r border-gray-200 bg-white p-5 !text-[13px] text-gray-600">
+        내용을 입력하세요.
+      </div>
+    </div>
+  );
+}

--- a/src/features/write/ui/Write.tsx
+++ b/src/features/write/ui/Write.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import StaticEditor from './StaticEditor';
 import { RichTextEditorHandle } from '@/shared/types';
 import { InputFieldTitle, PrimaryButton } from '@/shared/ui';
 import dynamic from 'next/dynamic';
@@ -9,6 +10,7 @@ import type { RefObject } from 'react';
 // Quill이 SSR 중 로딩되지 않도록 방지
 const RichTextEditor = dynamic(() => import('@/features/write/ui/RichTextEditor'), {
   ssr: false,
+  loading: () => <StaticEditor />,
 });
 
 interface WriteProps {


### PR DESCRIPTION
## 변경 사항
- 에디터 SSR 렌더링을 위한 폴백 UI 추가
- 에디터 CSS 수정
- 에디터에 색상 변경, 정렬추가

## 세부 설명
.

## 관련 이슈
reslove #179 

## 스크린샷 (선택 사항)
<img width="2304" height="2412" alt="image" src="https://github.com/user-attachments/assets/0e57a43e-6dec-4b59-bc9e-d2f0c1de5ea8" />


## 테스트 방법
.

## 체크리스트
- [x] 코드가 프로젝트의 코딩 스타일을 준수합니다
- [x] 자체 코드 리뷰를 수행했습니다
- [ ] 변경 사항에 대한 테스트가 추가/수정되었습니다
- [ ] 모든 테스트가 통과합니다
- [ ] 필요한 문서를 업데이트했습니다
