### PR TITLE
[FEAT] 미들웨어 기반 인증 가드 및 토큰 자동 갱신 구현

### DIFF
--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,21 +1,113 @@
+import { isValidToken } from '@/shared/lib';
+import { ResponseCookies } from 'next/dist/compiled/@edge-runtime/cookies';
 import { NextResponse } from 'next/server';
 import type { NextRequest } from 'next/server';
 
-export function middleware(request: NextRequest) {
+export async function middleware(request: NextRequest) {
+  const cookies = request.cookies;
+
   // 요청에서 'accesstoken' 쿠키를 가져옴
   const accesstoken = request.cookies.get('access_token');
 
   // 요청에서 'refreshtoken' 쿠키를 가져옴
-  const refreshtoken = request.cookies.get('access_token');
+  const refreshtoken = request.cookies.get('refresh_token');
 
   // 액세스 토큰 또는 리프레시 토큰이 없을 경우 로그인 페이지로 리다이렉트
   if (!accesstoken?.value || !refreshtoken?.value) {
-    return NextResponse.redirect(new URL('/?login=true', request.url));
+    const response = NextResponse.redirect(new URL('/?login=true', request.url));
+    // AT, RT 쿠키 삭제
+    response.cookies.delete({
+      name: 'access_token',
+      domain: '.trendnow.me',
+      path: '/',
+      sameSite: 'none',
+      secure: true,
+    });
+    response.cookies.delete({
+      name: 'refresh_token',
+      domain: '.trendnow.me',
+      path: '/',
+      sameSite: 'none',
+      secure: true,
+    });
+    return response;
+  }
+
+  // AT의 유효성을 검사
+  const { isAccessTokenValid } = isValidToken({
+    accesstoken: accesstoken?.value,
+  });
+
+  console.log('AT 유효성', isAccessTokenValid);
+
+  // AT가 유효하지 않을 경우 AT 재발급
+  if (!isAccessTokenValid) {
+    try {
+      // AT 재발급 API 호출
+      const response = await fetch(
+        `${process.env.NEXT_PUBLIC_REST_API_URL}/api/v1/member/access-token`,
+        {
+          method: 'POST',
+          headers: {
+            // 서버 환경이므로 쿠키 담기
+            Cookie: cookies.toString(),
+            // 'Referer' 헤더를 브라우저의 원본 URL로 설정해서 전달
+            Referer: request.url,
+          },
+        }
+      );
+      // 응답이 성공적이지 않으면 로그인 페이지로 리다이렉트
+      if (!response.ok) {
+        const response = NextResponse.redirect(new URL('/?login=true', request.url));
+        // AT, RT 쿠키 삭제
+        response.cookies.delete({
+          name: 'access_token',
+          domain: '.trendnow.me',
+          path: '/',
+          sameSite: 'none',
+          secure: true,
+        });
+        response.cookies.delete({
+          name: 'refresh_token',
+          domain: '.trendnow.me',
+          path: '/',
+          sameSite: 'none',
+          secure: true,
+        });
+        return response;
+      }
+      // 응답이 성공적이면 다음 요청을 처리
+      if (response.ok) {
+        const res = NextResponse.next();
+
+        // 응답 헤더에서 쿠키를 읽음
+        const responseCookies = new ResponseCookies(response.headers);
+
+        // 응답에서 'accesstoken' 쿠키를 가져옴
+        const accessToken = responseCookies.get('access_token');
+
+        if (accessToken) {
+          // 새 액세스 토큰을 설정
+          res.cookies.set(accessToken);
+        }
+        return res;
+      }
+    } catch (error) {
+      // 토큰 재발급 중 오류가 발생하면 콘솔에 출력하고 로그인 페이지로 리다이렉트
+      console.error('엑세스 토큰 재발급 중 오류 발생:', error);
+      return NextResponse.redirect(new URL('/?login=true', request.url));
+    }
   }
 
   return NextResponse.next();
 }
 
 export const config = {
-  matcher: ['/board/:boardId/write', '/hotboard/:boardId/write', '/mypage/:path*'],
+  matcher: [
+    '/board/:boardId/write',
+    '/board/:boardId/post/:postId/edit',
+    '/hotboard/:boardId/write',
+    '/hotboard/:boardId/post/:postId/edit',
+    '/mypage/:path*',
+  ],
 };

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -38,8 +38,6 @@ export async function middleware(request: NextRequest) {
     accesstoken: accesstoken?.value,
   });
 
-  console.log('AT 유효성', isAccessTokenValid);
-
   // AT가 유효하지 않을 경우 AT 재발급
   if (!isAccessTokenValid) {
     try {

--- a/src/shared/lib/index.ts
+++ b/src/shared/lib/index.ts
@@ -1,2 +1,3 @@
 export { cn } from './cn';
 export { getSHA256 } from './converters';
+export { isValidToken } from './is-valid-token';

--- a/src/shared/lib/is-valid-token.ts
+++ b/src/shared/lib/is-valid-token.ts
@@ -1,0 +1,31 @@
+export function isValidToken({ accesstoken }: { accesstoken?: string }): {
+  isAccessTokenValid: boolean;
+} {
+  // 현재 시간을 초 단위로 가져오기 (Unix Timestamp 형식)
+  const currentTime = Math.floor(Date.now() / 1000);
+
+  // 결과 객체를 초기화 (유효성 여부를 저장)
+  const result = {
+    isAccessTokenValid: false,
+  };
+
+  try {
+    // 액세스 토큰이 존재하면 디코딩하여 만료 시간(`exp`) 확인
+    if (accesstoken) {
+      // JWT의 payload 부분(base64) 디코딩
+      const accessTokenPayload = JSON.parse(atob(accesstoken.split('.')[1]));
+
+      // 현재 백엔드에서 exp 수정중
+      // result.isAccessTokenValid = accessTokenPayload.exp > currentTime;
+
+      // issued claim 기반으로 임시 구현 (30분)
+      result.isAccessTokenValid = accessTokenPayload.iat + 60 * 30 > currentTime;
+    }
+  } catch (error) {
+    // 디코딩 과정에서 발생한 오류를 로그로 출력
+    console.error('토큰 디코딩 실패:', error);
+  }
+
+  // 유효성 결과를 반환
+  return result;
+}


### PR DESCRIPTION
## 변경 사항
- 미들웨어 기반 인증 가드 및 토큰 자동 갱신 구현

## 세부 설명
- 마이페이지, 게시글 글쓰기, 게시글 편집 페이지에 로그인 상태에 따라 제어 (상세 로직은 노션 참고)
- 테스트를 위해서 현재 AT토큰이 만료시간이 30초로 설정
- `is-valid-token.ts` 파일의 `accessTokenPayload.iat + 30 > currentTime` 로직으로 만료 시간을 30초로 설정하면 토큰 갱신 테스트가 용이합니다. (현재는 30분으로 설정됨)
- 현재 백엔드에서 exp 값을 수정 중이며, 완료 시 주석 처리된 코드로 로직을 변경할 예정

## 관련 이슈
.

## 스크린샷 (선택 사항)
.

## 테스트 방법
.

## 체크리스트
- [x] 코드가 프로젝트의 코딩 스타일을 준수합니다
- [x] 자체 코드 리뷰를 수행했습니다
- [ ] 변경 사항에 대한 테스트가 추가/수정되었습니다
- [ ] 모든 테스트가 통과합니다
- [ ] 필요한 문서를 업데이트했습니다
