### PR TITLE
[FIX] Textarea 컴포넌트 분리 및 수정

### DIFF
--- a/src/app/test/inputField/page.tsx
+++ b/src/app/test/inputField/page.tsx
@@ -160,16 +160,16 @@ const Page = () => {
           <span className="w-full">MOBILE</span>
         </div>
         <div className="flex flex-row items-center gap-[16px] py-[8px]">
-          <Textarea placeholder="Description" type="basic" size="desktop" maxLength={200} />
-          <Textarea placeholder="Description" type="basic" size="mobile" maxLength={200} />
+          <Textarea placeholder="Description" variant="basic" size="desktop" maxLength={200} />
+          <Textarea placeholder="Description" variant="basic" size="mobile" maxLength={200} />
         </div>
         <div className="flex flex-row items-center gap-[16px] py-[8px]">
-          <Textarea placeholder="Description" type="disabled" size="desktop" maxLength={200} />
-          <Textarea placeholder="Description" type="disabled" size="mobile" maxLength={200} />
+          <Textarea placeholder="Description" variant="disabled" size="desktop" maxLength={200} />
+          <Textarea placeholder="Description" variant="disabled" size="mobile" maxLength={200} />
         </div>
         <div className="flex flex-row items-center gap-[16px] py-[8px]">
-          <Textarea placeholder="Description" type="error" size="desktop" maxLength={200} />
-          <Textarea placeholder="Description" type="error" size="mobile" maxLength={200} />
+          <Textarea placeholder="Description" variant="error" size="desktop" maxLength={200} />
+          <Textarea placeholder="Description" variant="error" size="mobile" maxLength={200} />
         </div>
         {/* Dropdown */}
         <div className="py-[8px] text-1xl font-medium">DROPDOWN</div>

--- a/src/shared/ui/text-field/Textarea.tsx
+++ b/src/shared/ui/text-field/Textarea.tsx
@@ -1,59 +1,50 @@
 import { cva, VariantProps } from 'class-variance-authority';
-import React, { ChangeEvent } from 'react';
+import { forwardRef, TextareaHTMLAttributes } from 'react';
 import { cn } from '@/shared/lib/';
 
 const textareaVariants = cva(
-  'border rounded-xl w-full font-light text-gray-800 focus:outline-none focus:border-gray-400',
+  'border rounded-xl w-full text-gray-800 focus:outline-none p-3 resize-none',
   {
     variants: {
       variant: {
-        basic: 'bg-white border-gray-200',
+        basic: 'bg-white border-gray-200 focus:border-gray-400',
         disabled: 'bg-gray-100 border-gray-300',
         error: 'bg-white border-negative',
-        active: '',
       },
       size: {
-        desktop: 'p-[12px] pr-[12px] text-md',
-        mobile: 'py-[12px] pl-[12px] pr-[8px] text-xs',
+        desktop: 'text-md',
+        mobile: 'text-xs',
       },
+    },
+    defaultVariants: {
+      variant: 'basic',
+      size: 'desktop',
     },
   }
 );
 
 interface TextareaProps
-  extends React.TextareaHTMLAttributes<HTMLTextAreaElement>,
+  extends TextareaHTMLAttributes<HTMLTextAreaElement>,
     VariantProps<typeof textareaVariants> {
   /**@param {String} variant 입력 상자의 상태에 따른 스타일을 고를 수 있습니다. */
-  type: 'basic' | 'disabled' | 'error' | 'active';
+  variant?: 'basic' | 'disabled' | 'error';
   /**@param {String} size PC 혹은 모바일 */
-  size: 'desktop' | 'mobile';
-  /**@param {String} maxLength 입력 가능한 텍스트 최대 길이 */
-  maxLength: number;
+  size?: 'desktop' | 'mobile';
 }
 
 /**
  * @see https://www.figma.com/design/2ks26SvLcpmEHmzSETR8ky/Trend-Now_Design-File?node-id=6-1531&t=6sPVBOpXARABMUkQ-4
  * */
-const Textarea = React.forwardRef<HTMLTextAreaElement, TextareaProps>(
-  ({ className, type: variant, size, maxLength, ...props }, ref) => {
-    const [textLength, setTextLength] = React.useState(0);
-    const handleTextChange = React.useCallback((e: ChangeEvent<HTMLTextAreaElement>) => {
-      setTextLength(e.target.value.length);
-    }, []);
+
+const Textarea = forwardRef<HTMLTextAreaElement, TextareaProps>(
+  ({ className, variant, size, disabled, ...props }, ref) => {
     return (
-      <span className="flex w-full flex-col gap-y-[4px]">
-        <textarea
-          ref={ref}
-          className={cn(textareaVariants({ variant, size }), className, 'resize-none')}
-          disabled={variant === 'disabled'}
-          onChange={handleTextChange}
-          maxLength={maxLength}
-          {...props}
-        />
-        <div className="flex justify-end text-2xs font-light">
-          {textLength} / {maxLength}
-        </div>
-      </span>
+      <textarea
+        ref={ref}
+        className={cn(textareaVariants({ variant, size }), className)}
+        disabled={variant === 'disabled' || disabled}
+        {...props}
+      />
     );
   }
 );

--- a/src/shared/ui/text-field/TextareaField.tsx
+++ b/src/shared/ui/text-field/TextareaField.tsx
@@ -1,0 +1,38 @@
+import { ChangeEvent, ComponentPropsWithoutRef, forwardRef, useCallback, useState } from 'react';
+import Textarea from './Textarea';
+
+interface TextareaFieldProps extends ComponentPropsWithoutRef<typeof Textarea> {
+  maxLength: number;
+}
+
+const TextareaField = forwardRef<HTMLTextAreaElement, TextareaFieldProps>(
+  ({ variant, size, maxLength, onChange, ...props }, ref) => {
+    const [textLength, setTextLength] = useState(0);
+    const handleTextChange = useCallback(
+      (e: ChangeEvent<HTMLTextAreaElement>) => {
+        setTextLength(e.target.value.length);
+        onChange?.(e);
+      },
+      [onChange]
+    );
+    return (
+      <div className="flex w-full flex-col gap-1">
+        <Textarea
+          ref={ref}
+          variant={variant}
+          size={size}
+          maxLength={maxLength}
+          onChange={handleTextChange}
+          {...props}
+        />
+        <div className="flex justify-end text-2xs">
+          {textLength} / {maxLength}
+        </div>
+      </div>
+    );
+  }
+);
+
+TextareaField.displayName = 'TextareaField';
+
+export default TextareaField;


### PR DESCRIPTION
## 변경 사항
- 기존 Textarea 컴포넌트를 Textarea만 사용하는 공통 컴포넌트로 분리하였습니다.
- 밑에 글자수를 나타내는 컴포넌트는 TextareaField로 분리하였습니다.
- 피그마에 따라서 css도 수정하였습니다.

## 세부 설명
.

## 관련 이슈
.

## 스크린샷 (선택 사항)
<img width="814" height="679" alt="image" src="https://github.com/user-attachments/assets/eb44ed7e-7544-44ca-a553-7005fe5ddb0e" />


## 테스트 방법
.

## 체크리스트
- [x] 코드가 프로젝트의 코딩 스타일을 준수합니다
- [x] 자체 코드 리뷰를 수행했습니다
- [ ] 변경 사항에 대한 테스트가 추가/수정되었습니다
- [ ] 모든 테스트가 통과합니다
- [ ] 필요한 문서를 업데이트했습니다
